### PR TITLE
Add Prefab command set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.GetComponen
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.AddComponent '{"path":"Main Camera","typeName":"BoxCollider"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.RemoveComponent '{"componentInstanceId":12345}' --json
 
+# Prefab operations
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.GetStatus '{"path":"Main Camera"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Instantiate '{"assetPath":"Assets/Prefabs/Enemy.prefab"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Save '{"path":"Main Camera","assetPath":"Assets/TestPrefab.prefab"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Apply '{"path":"MyPrefabInstance"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Unpack '{"path":"MyPrefabInstance"}' --json
+
 # Run Unity EditMode tests
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunEditMode --json
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ unicli exec GameObject.GetComponents --instanceId 1234
 unicli exec GameObject.AddComponent --path "Player" --typeName BoxCollider
 unicli exec GameObject.RemoveComponent --componentInstanceId 1234
 
+# Prefab operations
+unicli exec Prefab.GetStatus --path "MyPrefabInstance"
+unicli exec Prefab.Instantiate --assetPath "Assets/Prefabs/Enemy.prefab"
+unicli exec Prefab.Save --path "Player" --assetPath "Assets/Prefabs/Player.prefab"
+unicli exec Prefab.Apply --path "MyPrefabInstance"
+unicli exec Prefab.Unpack --path "MyPrefabInstance" --completely
+
 # Manage packages
 unicli exec PackageManager.List
 unicli exec PackageManager.Add --packageIdOrName com.unity.mathematics
@@ -160,6 +167,11 @@ The following commands are built in. You can also run `unicli commands` to see t
 | GameObject         | `GameObject.GetHierarchy`            | Get scene hierarchy                |
 | GameObject         | `GameObject.AddComponent`            | Add a component                    |
 | GameObject         | `GameObject.RemoveComponent`         | Remove a component                 |
+| Prefab             | `Prefab.GetStatus`                   | Get prefab instance status         |
+| Prefab             | `Prefab.Instantiate`                 | Instantiate a prefab into scene    |
+| Prefab             | `Prefab.Save`                        | Save GameObject as prefab          |
+| Prefab             | `Prefab.Apply`                       | Apply prefab overrides             |
+| Prefab             | `Prefab.Unpack`                      | Unpack a prefab instance           |
 | AssetDatabase      | `AssetDatabase.Find`                 | Search assets                      |
 | AssetDatabase      | `AssetDatabase.Import`               | Import an asset                    |
 | AssetDatabase      | `AssetDatabase.GetPath`              | Get asset path by GUID             |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4e7c2b1d3f84a5e9b6c0d1e2f3a4b5c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PrefabApplyHandler : CommandHandler<PrefabApplyRequest, PrefabApplyResponse>
+    {
+        public override string CommandName => CommandNames.Prefab.Apply;
+        public override string Description => "Apply overrides of a prefab instance to the source prefab asset";
+
+        protected override bool TryWriteFormatted(PrefabApplyResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Applied overrides of {response.gameObjectName} to {response.assetPath}");
+            else
+                writer.WriteLine("Failed to apply prefab overrides");
+
+            return true;
+        }
+
+        protected override ValueTask<PrefabApplyResponse> ExecuteAsync(PrefabApplyRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new PrefabApplyResponse());
+            }
+
+            var status = PrefabUtility.GetPrefabInstanceStatus(go);
+            if (status == PrefabInstanceStatus.NotAPrefab)
+            {
+                throw new CommandFailedException(
+                    $"'{go.name}' is not a prefab instance",
+                    new PrefabApplyResponse());
+            }
+
+            var assetPath = PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(go);
+
+            PrefabUtility.ApplyPrefabInstance(go, InteractionMode.UserAction);
+
+            return new ValueTask<PrefabApplyResponse>(new PrefabApplyResponse
+            {
+                gameObjectName = go.name,
+                assetPath = assetPath
+            });
+        }
+    }
+
+    [Serializable]
+    public class PrefabApplyRequest
+    {
+        public int instanceId;
+        public string path = "";
+    }
+
+    [Serializable]
+    public class PrefabApplyResponse
+    {
+        public string gameObjectName;
+        public string assetPath;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PrefabGetStatusHandler : CommandHandler<PrefabGetStatusRequest, PrefabGetStatusResponse>
+    {
+        public override string CommandName => CommandNames.Prefab.GetStatus;
+        public override string Description => "Get prefab instance status for a GameObject";
+
+        protected override bool TryWriteFormatted(PrefabGetStatusResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"{response.gameObjectName}: status={response.status}, asset={response.assetPath}");
+                if (response.isPrefabInstance)
+                    writer.WriteLine($"  hasOverrides={response.hasOverrides}");
+            }
+            else
+            {
+                writer.WriteLine("Failed to get prefab status");
+            }
+
+            return true;
+        }
+
+        protected override ValueTask<PrefabGetStatusResponse> ExecuteAsync(PrefabGetStatusRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new PrefabGetStatusResponse());
+            }
+
+            var status = PrefabUtility.GetPrefabInstanceStatus(go);
+            var isPrefabInstance = status != PrefabInstanceStatus.NotAPrefab;
+
+            var statusString = status switch
+            {
+                PrefabInstanceStatus.Connected => "Connected",
+                PrefabInstanceStatus.Disconnected => "Disconnected",
+                PrefabInstanceStatus.MissingAsset => "MissingAsset",
+                _ => "NotAPrefab"
+            };
+
+            var assetPath = isPrefabInstance
+                ? PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(go)
+                : "";
+
+            var hasOverrides = isPrefabInstance && PrefabUtility.HasPrefabInstanceAnyOverrides(go, false);
+
+            return new ValueTask<PrefabGetStatusResponse>(new PrefabGetStatusResponse
+            {
+                gameObjectName = go.name,
+                status = statusString,
+                assetPath = assetPath,
+                hasOverrides = hasOverrides,
+                isPrefabInstance = isPrefabInstance
+            });
+        }
+    }
+
+    [Serializable]
+    public class PrefabGetStatusRequest
+    {
+        public int instanceId;
+        public string path = "";
+    }
+
+    [Serializable]
+    public class PrefabGetStatusResponse
+    {
+        public string gameObjectName;
+        public string status;
+        public string assetPath;
+        public bool hasOverrides;
+        public bool isPrefabInstance;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PrefabInstantiateHandler : CommandHandler<PrefabInstantiateRequest, PrefabInstantiateResponse>
+    {
+        public override string CommandName => CommandNames.Prefab.Instantiate;
+        public override string Description => "Instantiate a prefab asset into the scene";
+
+        protected override bool TryWriteFormatted(PrefabInstantiateResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Instantiated {response.name} (instanceId={response.instanceId}) from {response.assetPath}");
+            else
+                writer.WriteLine("Failed to instantiate prefab");
+
+            return true;
+        }
+
+        protected override ValueTask<PrefabInstantiateResponse> ExecuteAsync(PrefabInstantiateRequest request)
+        {
+            if (string.IsNullOrEmpty(request.assetPath))
+                throw new ArgumentException("assetPath is required");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(request.assetPath);
+            if (prefab == null)
+            {
+                throw new CommandFailedException(
+                    $"Prefab not found at \"{request.assetPath}\"",
+                    new PrefabInstantiateResponse());
+            }
+
+            var instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            if (instance == null)
+            {
+                throw new CommandFailedException(
+                    $"Failed to instantiate prefab from \"{request.assetPath}\"",
+                    new PrefabInstantiateResponse());
+            }
+
+            Undo.RegisterCreatedObjectUndo(instance, "Instantiate Prefab");
+
+            var parent = GameObjectResolver.Resolve(request.parentInstanceId, request.parentPath);
+            if (parent != null)
+                instance.transform.SetParent(parent.transform, true);
+
+            return new ValueTask<PrefabInstantiateResponse>(new PrefabInstantiateResponse
+            {
+                instanceId = instance.GetInstanceID(),
+                name = instance.name,
+                assetPath = request.assetPath
+            });
+        }
+    }
+
+    [Serializable]
+    public class PrefabInstantiateRequest
+    {
+        public string assetPath;
+        public int parentInstanceId;
+        public string parentPath = "";
+    }
+
+    [Serializable]
+    public class PrefabInstantiateResponse
+    {
+        public int instanceId;
+        public string name;
+        public string assetPath;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PrefabSaveHandler : CommandHandler<PrefabSaveRequest, PrefabSaveResponse>
+    {
+        public override string CommandName => CommandNames.Prefab.Save;
+        public override string Description => "Save a GameObject as a prefab asset";
+
+        protected override bool TryWriteFormatted(PrefabSaveResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Saved {response.gameObjectName} as prefab at {response.assetPath}");
+            else
+                writer.WriteLine("Failed to save prefab");
+
+            return true;
+        }
+
+        protected override ValueTask<PrefabSaveResponse> ExecuteAsync(PrefabSaveRequest request)
+        {
+            if (string.IsNullOrEmpty(request.assetPath))
+                throw new ArgumentException("assetPath is required");
+
+            if (!request.assetPath.EndsWith(".prefab"))
+            {
+                throw new CommandFailedException(
+                    $"assetPath must end with .prefab (got \"{request.assetPath}\")",
+                    new PrefabSaveResponse());
+            }
+
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new PrefabSaveResponse());
+            }
+
+            var prefab = PrefabUtility.SaveAsPrefabAsset(go, request.assetPath, out var success);
+            if (!success || prefab == null)
+            {
+                throw new CommandFailedException(
+                    $"Failed to save '{go.name}' as prefab at \"{request.assetPath}\"",
+                    new PrefabSaveResponse());
+            }
+
+            return new ValueTask<PrefabSaveResponse>(new PrefabSaveResponse
+            {
+                gameObjectName = go.name,
+                assetPath = request.assetPath
+            });
+        }
+    }
+
+    [Serializable]
+    public class PrefabSaveRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public string assetPath;
+    }
+
+    [Serializable]
+    public class PrefabSaveResponse
+    {
+        public string gameObjectName;
+        public string assetPath;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PrefabUnpackHandler : CommandHandler<PrefabUnpackRequest, PrefabUnpackResponse>
+    {
+        public override string CommandName => CommandNames.Prefab.Unpack;
+        public override string Description => "Unpack a prefab instance, disconnecting it from the source prefab";
+
+        protected override bool TryWriteFormatted(PrefabUnpackResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Unpacked {response.gameObjectName} (mode={response.unpackMode})");
+            else
+                writer.WriteLine("Failed to unpack prefab");
+
+            return true;
+        }
+
+        protected override ValueTask<PrefabUnpackResponse> ExecuteAsync(PrefabUnpackRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new PrefabUnpackResponse());
+            }
+
+            var status = PrefabUtility.GetPrefabInstanceStatus(go);
+            if (status == PrefabInstanceStatus.NotAPrefab)
+            {
+                throw new CommandFailedException(
+                    $"'{go.name}' is not a prefab instance",
+                    new PrefabUnpackResponse());
+            }
+
+            var mode = request.completely
+                ? PrefabUnpackMode.Completely
+                : PrefabUnpackMode.OutermostRoot;
+
+            PrefabUtility.UnpackPrefabInstance(go, mode, InteractionMode.UserAction);
+
+            return new ValueTask<PrefabUnpackResponse>(new PrefabUnpackResponse
+            {
+                gameObjectName = go.name,
+                unpackMode = request.completely ? "Completely" : "OutermostRoot"
+            });
+        }
+    }
+
+    [Serializable]
+    public class PrefabUnpackRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public bool completely;
+    }
+
+    [Serializable]
+    public class PrefabUnpackResponse
+    {
+        public string gameObjectName;
+        public string unpackMode;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -60,6 +60,15 @@ namespace UniCli.Server.Editor
             public const string Search = "PackageManager.Search";
         }
 
+        public static class Prefab
+        {
+            public const string GetStatus = "Prefab.GetStatus";
+            public const string Instantiate = "Prefab.Instantiate";
+            public const string Save = "Prefab.Save";
+            public const string Apply = "Prefab.Apply";
+            public const string Unpack = "Prefab.Unpack";
+        }
+
         public static class AssemblyDefinition
         {
             public const string List = "AssemblyDefinition.List";


### PR DESCRIPTION
## Summary

- Add 5 Prefab commands for CLI-driven prefab workflows:
  - `Prefab.GetStatus` — query prefab instance status, asset path, and override state
  - `Prefab.Instantiate` — place a prefab asset into the scene with optional parent
  - `Prefab.Save` — save a GameObject as a `.prefab` asset
  - `Prefab.Apply` — apply instance overrides back to the source prefab
  - `Prefab.Unpack` — disconnect a prefab instance (OutermostRoot or Completely)
- Update `CommandNames.cs` with `Prefab` category
- Update README.md and CLAUDE.md with examples

## Test plan

- [x] Unity compilation passes (0 errors)
- [x] All existing EditMode tests pass (8/8)
- [x] `Prefab.GetStatus` returns `NotAPrefab` for regular GameObjects
- [x] `Prefab.Save` creates a `.prefab` asset
- [x] `Prefab.Instantiate` places the prefab in the scene as a connected instance
- [x] `Prefab.GetStatus` detects `Connected` status and `hasOverrides` after modification
- [x] `Prefab.Apply` clears overrides by applying to source prefab
- [x] `Prefab.Unpack` disconnects the instance (status becomes `NotAPrefab`)
- [x] Error cases: non-prefab Apply, non-existent asset Instantiate, wrong extension Save