### PR TITLE
Add AssetDatabase.Delete command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Save '{"path":"
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Apply '{"path":"MyPrefabInstance"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Unpack '{"path":"MyPrefabInstance"}' --json
 
+# AssetDatabase operations
+UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec AssetDatabase.Delete '{"path":"Assets/Prefabs/Old.prefab"}' --json
+
 # Run Unity EditMode tests
 UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunEditMode --json
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ unicli exec Prefab.Save --path "Player" --assetPath "Assets/Prefabs/Player.prefa
 unicli exec Prefab.Apply --path "MyPrefabInstance"
 unicli exec Prefab.Unpack --path "MyPrefabInstance" --completely
 
+# Delete an asset
+unicli exec AssetDatabase.Delete --path "Assets/Prefabs/Old.prefab"
+
 # Manage packages
 unicli exec PackageManager.List
 unicli exec PackageManager.Add --packageIdOrName com.unity.mathematics
@@ -175,6 +178,7 @@ The following commands are built in. You can also run `unicli commands` to see t
 | AssetDatabase      | `AssetDatabase.Find`                 | Search assets                      |
 | AssetDatabase      | `AssetDatabase.Import`               | Import an asset                    |
 | AssetDatabase      | `AssetDatabase.GetPath`              | Get asset path by GUID             |
+| AssetDatabase      | `AssetDatabase.Delete`               | Delete an asset                    |
 | Project            | `Project.Inspect`                    | Get project info                   |
 | PackageManager     | `PackageManager.List`                | List packages                      |
 | PackageManager     | `PackageManager.Add`                 | Add a package                      |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/AssetDatabase/AssetDeleteHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/AssetDatabase/AssetDeleteHandler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class AssetDeleteHandler : CommandHandler<AssetDeleteRequest, AssetDeleteResponse>
+    {
+        public override string CommandName => CommandNames.AssetDatabase.Delete;
+        public override string Description => "Delete an asset";
+
+        protected override ValueTask<AssetDeleteResponse> ExecuteAsync(AssetDeleteRequest request)
+        {
+            if (string.IsNullOrEmpty(request.path))
+                throw new ArgumentException("path must be specified");
+
+            var assetType = AssetDatabase.GetMainAssetTypeAtPath(request.path);
+            if (assetType == null)
+            {
+                throw new CommandFailedException(
+                    $"Asset not found: {request.path}",
+                    new AssetDeleteResponse { path = request.path, type = "" });
+            }
+
+            var typeName = assetType.Name;
+
+            if (!AssetDatabase.DeleteAsset(request.path))
+            {
+                throw new CommandFailedException(
+                    $"Failed to delete asset: {request.path}",
+                    new AssetDeleteResponse { path = request.path, type = typeName });
+            }
+
+            return new ValueTask<AssetDeleteResponse>(new AssetDeleteResponse
+            {
+                path = request.path,
+                type = typeName
+            });
+        }
+    }
+
+    [Serializable]
+    public class AssetDeleteRequest
+    {
+        public string path = "";
+    }
+
+    [Serializable]
+    public class AssetDeleteResponse
+    {
+        public string path;
+        public string type;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/AssetDatabase/AssetDeleteHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/AssetDatabase/AssetDeleteHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02f8b4af9a31c4884b521d67a2fbbce9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -45,6 +45,7 @@ namespace UniCli.Server.Editor
             public const string Find = "AssetDatabase.Find";
             public const string Import = "AssetDatabase.Import";
             public const string GetPath = "AssetDatabase.GetPath";
+            public const string Delete = "AssetDatabase.Delete";
         }
 
         public static class Project


### PR DESCRIPTION
## Summary
- Add `AssetDatabase.Delete` command to delete assets via CLI
- Validates path is non-empty, asset exists, and deletion succeeds
- Returns deleted asset's path and type on success

## Test plan
- [x] Unity compilation passes (0 errors, 0 warnings)
- [x] EditMode tests pass (8/8)
- [x] Manual test: create and delete a prefab asset
- [x] Manual test: error case with non-existent asset