### PR TITLE
Add Scene category commands

### DIFF
--- a/.claude-plugin/unicli/skills/unicli/SKILL.md
+++ b/.claude-plugin/unicli/skills/unicli/SKILL.md
@@ -99,6 +99,13 @@ unicli exec GameObject.Find --includeInactive
 | `AssemblyDefinition.Create` | Create a new assembly definition |
 | `AssemblyDefinition.AddReference` | Add an asmdef reference |
 | `AssemblyDefinition.RemoveReference` | Remove an asmdef reference |
+| `Scene.List` | List all loaded scenes |
+| `Scene.GetActive` | Get the active scene |
+| `Scene.SetActive` | Set the active scene |
+| `Scene.Open` | Open a scene by asset path |
+| `Scene.Close` | Close a loaded scene |
+| `Scene.Save` | Save a scene or all open scenes |
+| `Scene.New` | Create a new scene |
 
 ## Common Workflows
 
@@ -139,6 +146,19 @@ unicli exec Prefab.Instantiate --assetPath "Assets/Prefabs/Enemy.prefab" --json
 unicli exec Prefab.Save --path "Player" --assetPath "Assets/Prefabs/Player.prefab" --json
 unicli exec Prefab.Apply --path "MyPrefabInstance" --json
 unicli exec Prefab.Unpack --path "MyPrefabInstance" --json
+```
+
+**Scene operations:**
+
+```bash
+unicli exec Scene.List --json
+unicli exec Scene.GetActive --json
+unicli exec Scene.Open --path "Assets/Scenes/Level1.unity" --json
+unicli exec Scene.Open --path "Assets/Scenes/Additive.unity" --additive --json
+unicli exec Scene.SetActive --name "Level1" --json
+unicli exec Scene.Save --all --json
+unicli exec Scene.Close --name "Additive" --json
+unicli exec Scene.New --empty --additive --json
 ```
 
 **Delete an asset:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,37 +21,47 @@ dotnet build src/UniCli.Client
 
 # Publish Client and test with the built binary
 dotnet publish src/UniCli.Client -o .build
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client commands --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Compile --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli commands --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 
 # GameObject operations
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.GetComponents '{"path":"Main Camera"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.AddComponent '{"path":"Main Camera","typeName":"BoxCollider"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec GameObject.RemoveComponent '{"componentInstanceId":12345}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.GetComponents '{"path":"Main Camera"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.AddComponent '{"path":"Main Camera","typeName":"BoxCollider"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.RemoveComponent '{"componentInstanceId":12345}' --json
 
 # Prefab operations
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.GetStatus '{"path":"Main Camera"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Instantiate '{"assetPath":"Assets/Prefabs/Enemy.prefab"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Save '{"path":"Main Camera","assetPath":"Assets/TestPrefab.prefab"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Apply '{"path":"MyPrefabInstance"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Prefab.Unpack '{"path":"MyPrefabInstance"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.GetStatus '{"path":"Main Camera"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Instantiate '{"assetPath":"Assets/Prefabs/Enemy.prefab"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Save '{"path":"Main Camera","assetPath":"Assets/TestPrefab.prefab"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Apply '{"path":"MyPrefabInstance"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Unpack '{"path":"MyPrefabInstance"}' --json
+
+# Scene operations
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.List --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.GetActive --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Open '{"path":"Assets/Scenes/SampleScene.unity"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Open '{"path":"Assets/Scenes/Additive.unity","additive":true}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.SetActive '{"name":"SampleScene"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Save '{"all":true}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Close '{"name":"Additive"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.New '{"empty":true,"additive":true}' --json
 
 # AssetDatabase operations
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec AssetDatabase.Delete '{"path":"Assets/Prefabs/Old.prefab"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Delete '{"path":"Assets/Prefabs/Old.prefab"}' --json
 
 # Run Unity EditMode tests
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunEditMode --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --json
 
 # Run Unity PlayMode tests
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunPlayMode --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --json
 
 # Compile Unity project (also serves as a build verification for the server)
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Compile --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 ```
 
 ## Testing
 
-When testing CLI behavior, always publish first with `dotnet publish src/UniCli.Client -o .build`, then test with `.build/UniCli.Client` directly. Do not use `dotnet run`.
+When testing CLI behavior, always publish first with `dotnet publish src/UniCli.Client -o .build`, then test with `.build/unicli` directly. Do not use `dotnet run`.
 
 ### Server-side verification (required)
 
@@ -62,11 +72,11 @@ When testing CLI behavior, always publish first with `dotnet publish src/UniCli.
 dotnet publish src/UniCli.Client -o .build
 
 # 2. Verify server-side compilation (required)
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec Compile --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 
 # 3. Run tests
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunEditMode --json
-UNICLI_PROJECT=src/UniCli.Unity .build/UniCli.Client exec TestRunner.RunPlayMode --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --json
 ```
 
 ### Maintaining documentation

--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ unicli exec PackageManager.List
 unicli exec PackageManager.Add --packageIdOrName com.unity.mathematics
 unicli exec PackageManager.Remove --packageIdOrName com.unity.mathematics
 
+# Scene operations
+unicli exec Scene.List
+unicli exec Scene.GetActive
+unicli exec Scene.Open --path "Assets/Scenes/Level1.unity"
+unicli exec Scene.Open --path "Assets/Scenes/Additive.unity" --additive
+unicli exec Scene.SetActive --name "Level1"
+unicli exec Scene.Save --all
+unicli exec Scene.Save --name "Level1" --saveAsPath "Assets/Scenes/Level1_backup.unity"
+unicli exec Scene.Close --name "Additive"
+unicli exec Scene.New --empty --additive
+
 # Execute menu items
 unicli exec Menu.Execute --menuPath "Window/General/Console"
 
@@ -189,6 +200,13 @@ The following commands are built in. You can also run `unicli commands` to see t
 | AssemblyDefinition | `AssemblyDefinition.Create`          | Create assembly definition         |
 | AssemblyDefinition | `AssemblyDefinition.AddReference`    | Add asmdef reference               |
 | AssemblyDefinition | `AssemblyDefinition.RemoveReference` | Remove asmdef reference            |
+| Scene              | `Scene.List`                         | List all loaded scenes             |
+| Scene              | `Scene.GetActive`                    | Get the active scene               |
+| Scene              | `Scene.SetActive`                    | Set the active scene               |
+| Scene              | `Scene.Open`                         | Open a scene by asset path         |
+| Scene              | `Scene.Close`                        | Close a loaded scene               |
+| Scene              | `Scene.Save`                         | Save a scene or all open scenes    |
+| Scene              | `Scene.New`                          | Create a new scene                 |
 
 Use `unicli exec <command> --help` to see parameters for any command.
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41a1b208b04d54c3aabbb677d7592cab
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneCloseHandler : CommandHandler<SceneCloseRequest, SceneCloseResponse>
+    {
+        public override string CommandName => CommandNames.Scene.Close;
+        public override string Description => "Close a loaded scene";
+
+        protected override bool TryWriteFormatted(SceneCloseResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Closed scene: {response.name} ({response.path}) removed={response.removed}");
+            else
+                writer.WriteLine("Failed to close scene");
+
+            return true;
+        }
+
+        protected override ValueTask<SceneCloseResponse> ExecuteAsync(SceneCloseRequest request)
+        {
+            var scene = SceneResolver.Resolve(request.name, request.path, request.sceneIndex);
+            if (!scene.IsValid())
+            {
+                throw new CommandFailedException(
+                    $"Scene not found (name=\"{request.name}\", path=\"{request.path}\", sceneIndex={request.sceneIndex})",
+                    new SceneCloseResponse());
+            }
+
+            var sceneName = scene.name;
+            var scenePath = scene.path;
+
+            var closed = EditorSceneManager.CloseScene(scene, request.removeScene);
+            if (!closed)
+            {
+                throw new CommandFailedException(
+                    $"Failed to close scene '{sceneName}' (it may be the only loaded scene)",
+                    new SceneCloseResponse { name = sceneName, path = scenePath });
+            }
+
+            return new ValueTask<SceneCloseResponse>(new SceneCloseResponse
+            {
+                name = sceneName,
+                path = scenePath,
+                removed = request.removeScene
+            });
+        }
+    }
+
+    [Serializable]
+    public class SceneCloseRequest
+    {
+        public string name = "";
+        public string path = "";
+        public int sceneIndex = -1;
+        public bool removeScene;
+    }
+
+    [Serializable]
+    public class SceneCloseResponse
+    {
+        public string name;
+        public string path;
+        public bool removed;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc7e6f2065e654fbaa5acfe2966eb9a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneGetActiveHandler : CommandHandler<Unit, SceneInfoResponse>
+    {
+        public override string CommandName => CommandNames.Scene.GetActive;
+        public override string Description => "Get the active scene";
+
+        protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"{response.name} ({response.path}) buildIndex={response.buildIndex} dirty={response.isDirty}");
+            else
+                writer.WriteLine("Failed to get active scene");
+
+            return true;
+        }
+
+        protected override ValueTask<SceneInfoResponse> ExecuteAsync(Unit request)
+        {
+            var scene = SceneManager.GetActiveScene();
+
+            return new ValueTask<SceneInfoResponse>(SceneInfoResponse.From(scene));
+        }
+    }
+
+    [Serializable]
+    public class SceneInfoResponse
+    {
+        public string name;
+        public string path;
+        public int buildIndex;
+        public bool isDirty;
+        public bool isLoaded;
+        public int rootCount;
+
+        public static SceneInfoResponse From(Scene scene)
+        {
+            return new SceneInfoResponse
+            {
+                name = scene.name,
+                path = scene.path,
+                buildIndex = scene.buildIndex,
+                isDirty = scene.isDirty,
+                isLoaded = scene.isLoaded,
+                rootCount = scene.rootCount
+            };
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 648c84ebe5b8e4550aedd56907fe2415
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneListHandler : CommandHandler<Unit, SceneListResponse>
+    {
+        public override string CommandName => CommandNames.Scene.List;
+        public override string Description => "List all loaded scenes";
+
+        protected override bool TryWriteFormatted(SceneListResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success || response.scenes == null || response.scenes.Length == 0)
+            {
+                writer.WriteLine("No scenes loaded.");
+                return true;
+            }
+
+            writer.WriteLine($"Active scene: {response.activeSceneName}");
+            writer.WriteLine($"Loaded scenes ({response.scenes.Length}):");
+
+            foreach (var scene in response.scenes)
+            {
+                var dirty = scene.isDirty ? " [dirty]" : "";
+                writer.WriteLine($"  {scene.name} ({scene.path}) buildIndex={scene.buildIndex}{dirty}");
+            }
+
+            return true;
+        }
+
+        protected override ValueTask<SceneListResponse> ExecuteAsync(Unit request)
+        {
+            var count = SceneManager.sceneCount;
+            var scenes = new SceneInfo[count];
+            var activeScene = SceneManager.GetActiveScene();
+
+            for (var i = 0; i < count; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                scenes[i] = new SceneInfo
+                {
+                    name = scene.name,
+                    path = scene.path,
+                    buildIndex = scene.buildIndex,
+                    isDirty = scene.isDirty,
+                    isLoaded = scene.isLoaded,
+                    rootCount = scene.rootCount
+                };
+            }
+
+            return new ValueTask<SceneListResponse>(new SceneListResponse
+            {
+                scenes = scenes,
+                activeSceneName = activeScene.name
+            });
+        }
+    }
+
+    [Serializable]
+    public class SceneListResponse
+    {
+        public SceneInfo[] scenes;
+        public string activeSceneName;
+    }
+
+    [Serializable]
+    public class SceneInfo
+    {
+        public string name;
+        public string path;
+        public int buildIndex;
+        public bool isDirty;
+        public bool isLoaded;
+        public int rootCount;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da1a3e7fecdf94b5b8d0fac637a39df1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneNewHandler : CommandHandler<SceneNewRequest, SceneInfoResponse>
+    {
+        public override string CommandName => CommandNames.Scene.New;
+        public override string Description => "Create a new scene";
+
+        protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Created new scene: {response.name}");
+            else
+                writer.WriteLine("Failed to create new scene");
+
+            return true;
+        }
+
+        protected override ValueTask<SceneInfoResponse> ExecuteAsync(SceneNewRequest request)
+        {
+            var setup = request.empty
+                ? NewSceneSetup.EmptyScene
+                : NewSceneSetup.DefaultGameObjects;
+
+            var mode = request.additive
+                ? NewSceneMode.Additive
+                : NewSceneMode.Single;
+
+            var scene = EditorSceneManager.NewScene(setup, mode);
+            if (!scene.IsValid())
+            {
+                throw new CommandFailedException(
+                    "Failed to create new scene",
+                    new SceneInfoResponse());
+            }
+
+            return new ValueTask<SceneInfoResponse>(SceneInfoResponse.From(scene));
+        }
+    }
+
+    [Serializable]
+    public class SceneNewRequest
+    {
+        public bool empty;
+        public bool additive;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8153eaf0fb834a7fad226b3caac4992
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneOpenHandler : CommandHandler<SceneOpenRequest, SceneInfoResponse>
+    {
+        public override string CommandName => CommandNames.Scene.Open;
+        public override string Description => "Open a scene by asset path";
+
+        protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Opened scene: {response.name} ({response.path})");
+            else
+                writer.WriteLine("Failed to open scene");
+
+            return true;
+        }
+
+        protected override ValueTask<SceneInfoResponse> ExecuteAsync(SceneOpenRequest request)
+        {
+            if (string.IsNullOrEmpty(request.path))
+                throw new ArgumentException("path is required");
+
+            var mode = request.additive
+                ? OpenSceneMode.Additive
+                : OpenSceneMode.Single;
+
+            var scene = EditorSceneManager.OpenScene(request.path, mode);
+            if (!scene.IsValid())
+            {
+                throw new CommandFailedException(
+                    $"Failed to open scene at \"{request.path}\"",
+                    new SceneInfoResponse());
+            }
+
+            return new ValueTask<SceneInfoResponse>(SceneInfoResponse.From(scene));
+        }
+    }
+
+    [Serializable]
+    public class SceneOpenRequest
+    {
+        public string path;
+        public bool additive;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cef2e53236d145fc818f5ebec11a369
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneResolver.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneResolver.cs
@@ -1,0 +1,29 @@
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal static class SceneResolver
+    {
+        public static Scene Resolve(string name, string path, int sceneIndex = -1)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                var scene = SceneManager.GetSceneByPath(path);
+                if (scene.IsValid())
+                    return scene;
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                var scene = SceneManager.GetSceneByName(name);
+                if (scene.IsValid())
+                    return scene;
+            }
+
+            if (sceneIndex >= 0 && sceneIndex < SceneManager.sceneCount)
+                return SceneManager.GetSceneAt(sceneIndex);
+
+            return default;
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneResolver.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c2e5592883fb48b9a83a3c12380a1e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneSaveHandler : CommandHandler<SceneSaveRequest, SceneSaveResponse>
+    {
+        public override string CommandName => CommandNames.Scene.Save;
+        public override string Description => "Save a scene or all open scenes";
+
+        protected override bool TryWriteFormatted(SceneSaveResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"Saved {response.savedCount} scene(s):");
+                if (response.savedScenePaths != null)
+                {
+                    foreach (var p in response.savedScenePaths)
+                        writer.WriteLine($"  {p}");
+                }
+            }
+            else
+            {
+                writer.WriteLine("Failed to save scene(s)");
+            }
+
+            return true;
+        }
+
+        protected override ValueTask<SceneSaveResponse> ExecuteAsync(SceneSaveRequest request)
+        {
+            if (request.all)
+                return SaveAllScenes();
+
+            return SaveSingleScene(request);
+        }
+
+        private static ValueTask<SceneSaveResponse> SaveAllScenes()
+        {
+            var saved = EditorSceneManager.SaveOpenScenes();
+            if (!saved)
+            {
+                throw new CommandFailedException(
+                    "Failed to save open scenes",
+                    new SceneSaveResponse { savedScenePaths = Array.Empty<string>(), savedCount = 0 });
+            }
+
+            var paths = new List<string>();
+            for (var i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                if (scene.isLoaded && !string.IsNullOrEmpty(scene.path))
+                    paths.Add(scene.path);
+            }
+
+            return new ValueTask<SceneSaveResponse>(new SceneSaveResponse
+            {
+                savedScenePaths = paths.ToArray(),
+                savedCount = paths.Count
+            });
+        }
+
+        private static ValueTask<SceneSaveResponse> SaveSingleScene(SceneSaveRequest request)
+        {
+            Scene scene;
+
+            if (!string.IsNullOrEmpty(request.name) || !string.IsNullOrEmpty(request.path) || request.sceneIndex >= 0)
+            {
+                scene = SceneResolver.Resolve(request.name, request.path, request.sceneIndex);
+                if (!scene.IsValid())
+                {
+                    throw new CommandFailedException(
+                        $"Scene not found (name=\"{request.name}\", path=\"{request.path}\")",
+                        new SceneSaveResponse { savedScenePaths = Array.Empty<string>(), savedCount = 0 });
+                }
+            }
+            else
+            {
+                scene = SceneManager.GetActiveScene();
+            }
+
+            var savePath = !string.IsNullOrEmpty(request.saveAsPath)
+                ? request.saveAsPath
+                : scene.path;
+
+            var saved = EditorSceneManager.SaveScene(scene, savePath);
+            if (!saved)
+            {
+                throw new CommandFailedException(
+                    $"Failed to save scene '{scene.name}' to \"{savePath}\"",
+                    new SceneSaveResponse { savedScenePaths = Array.Empty<string>(), savedCount = 0 });
+            }
+
+            return new ValueTask<SceneSaveResponse>(new SceneSaveResponse
+            {
+                savedScenePaths = new[] { savePath },
+                savedCount = 1
+            });
+        }
+    }
+
+    [Serializable]
+    public class SceneSaveRequest
+    {
+        public string name = "";
+        public string path = "";
+        public int sceneIndex = -1;
+        public string saveAsPath = "";
+        public bool all;
+    }
+
+    [Serializable]
+    public class SceneSaveResponse
+    {
+        public string[] savedScenePaths;
+        public int savedCount;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40cc0745f9b4c4453bdfa3733489912e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SceneSetActiveHandler : CommandHandler<SceneSetActiveRequest, SceneInfoResponse>
+    {
+        public override string CommandName => CommandNames.Scene.SetActive;
+        public override string Description => "Set the active scene";
+
+        protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Active scene set to: {response.name} ({response.path})");
+            else
+                writer.WriteLine("Failed to set active scene");
+
+            return true;
+        }
+
+        protected override ValueTask<SceneInfoResponse> ExecuteAsync(SceneSetActiveRequest request)
+        {
+            var scene = SceneResolver.Resolve(request.name, request.path, request.sceneIndex);
+            if (!scene.IsValid())
+            {
+                throw new CommandFailedException(
+                    $"Scene not found (name=\"{request.name}\", path=\"{request.path}\")",
+                    new SceneInfoResponse());
+            }
+
+            if (!scene.isLoaded)
+            {
+                throw new CommandFailedException(
+                    $"Scene '{scene.name}' is not loaded",
+                    new SceneInfoResponse());
+            }
+
+            if (!SceneManager.SetActiveScene(scene))
+            {
+                throw new CommandFailedException(
+                    $"Failed to set '{scene.name}' as active scene",
+                    new SceneInfoResponse());
+            }
+
+            return new ValueTask<SceneInfoResponse>(SceneInfoResponse.From(scene));
+        }
+    }
+
+    [Serializable]
+    public class SceneSetActiveRequest
+    {
+        public string name = "";
+        public string path = "";
+        public int sceneIndex = -1;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a37ddfaddd1741288e1194c37e5c3cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -78,5 +78,16 @@ namespace UniCli.Server.Editor
             public const string AddReference = "AssemblyDefinition.AddReference";
             public const string RemoveReference = "AssemblyDefinition.RemoveReference";
         }
+
+        public static class Scene
+        {
+            public const string List = "Scene.List";
+            public const string GetActive = "Scene.GetActive";
+            public const string SetActive = "Scene.SetActive";
+            public const string Open = "Scene.Open";
+            public const string Close = "Scene.Close";
+            public const string Save = "Scene.Save";
+            public const string New = "Scene.New";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Implement 7 Scene commands (`Scene.List`, `Scene.GetActive`, `Scene.SetActive`, `Scene.Open`, `Scene.Close`, `Scene.Save`, `Scene.New`) using `EditorSceneManager` / `SceneManager` APIs
- Add `SceneResolver` utility with `sceneIndex` fallback for resolving unnamed/unsaved scenes
- Fix binary name references in CLAUDE.md (`.build/UniCli.Client` → `.build/unicli`)
- Update README.md, SKILL.md, CLAUDE.md with Scene command documentation

## Test plan
- [x] Unity compilation passes (0 errors, 0 warnings)
- [x] EditMode tests pass (8/8)
- [x] All 7 Scene commands appear in `unicli commands`
- [x] `Scene.List` / `Scene.GetActive` / `Scene.Save --all` verified
- [x] Additive scene workflow verified: `Scene.New` (additive) → `Scene.List` (2 scenes) → `Scene.SetActive` → `Scene.Close` (sceneIndex) → `Scene.List` (1 scene)