### PR TITLE
Add CompilePlayer command for platform-specific script compilation

### DIFF
--- a/.claude-plugin/unicli/skills/unicli/SKILL.md
+++ b/.claude-plugin/unicli/skills/unicli/SKILL.md
@@ -65,6 +65,7 @@ unicli exec GameObject.Find --includeInactive
 | Command | Description |
 |---|---|
 | `Compile` | Compile scripts and return results |
+| `CompilePlayer` | Compile player scripts for a build target |
 | `Console.GetLog` | Get console log entries |
 | `Console.Clear` | Clear console |
 | `PlayMode.Enter` | Enter play mode |
@@ -113,6 +114,14 @@ unicli exec GameObject.Find --includeInactive
 
 ```bash
 unicli exec Compile --json
+```
+
+**Compile player scripts for a specific build target:**
+
+```bash
+unicli exec CompilePlayer --json
+unicli exec CompilePlayer --target Android --json
+unicli exec CompilePlayer --target iOS --extraScriptingDefines MY_DEFINE --json
 ```
 
 **Run tests:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,11 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --json
 # Run Unity PlayMode tests
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --json
 
+# Compile player scripts for a specific build target
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec CompilePlayer --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec CompilePlayer '{"target":"Android"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec CompilePlayer '{"target":"iOS","extraScriptingDefines":["MY_DEFINE"]}' --json
+
 # Compile Unity project (also serves as a build verification for the server)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ unicli exec GameObject.Find --help
 # Compile scripts
 unicli exec Compile
 
+# Compile player scripts for a specific build target
+unicli exec CompilePlayer
+unicli exec CompilePlayer --target Android
+unicli exec CompilePlayer --target iOS --extraScriptingDefines MY_DEFINE
+
 # Run tests
 unicli exec TestRunner.RunEditMode
 unicli exec TestRunner.RunPlayMode
@@ -166,6 +171,7 @@ The following commands are built in. You can also run `unicli commands` to see t
 | Category           | Command                              | Description                        |
 |--------------------|--------------------------------------|------------------------------------|
 | Core               | `Compile`                            | Compile scripts and return results |
+| Core               | `CompilePlayer`                      | Compile player scripts for a build target |
 | Console            | `Console.GetLog`                     | Get console log entries            |
 | Console            | `Console.Clear`                      | Clear console                      |
 | PlayMode           | `PlayMode.Enter`                     | Enter play mode                    |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/CompilePlayerHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/CompilePlayerHandler.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEditor.Build.Player;
+using UnityEditor.Compilation;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class CompilePlayerHandler : CommandHandler<CompilePlayerRequest, CompilePlayerResponse>
+    {
+        public override string CommandName => CommandNames.CompilePlayer;
+        public override string Description => "Compile player scripts for a specific build target";
+
+        protected override bool TryWriteFormatted(CompilePlayerResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Player compilation succeeded for {response.target} ({response.errorCount} errors, {response.warningCount} warnings, {response.assemblyCount} assemblies)");
+            else
+                writer.WriteLine($"Player compilation failed for {response.target} ({response.errorCount} errors, {response.warningCount} warnings)");
+
+            WriteIssues(writer, response.errors);
+            WriteIssues(writer, response.warnings);
+
+            return true;
+        }
+
+        private static void WriteIssues(IFormatWriter writer, CompileIssue[] issues)
+        {
+            if (issues == null) return;
+
+            foreach (var issue in issues)
+            {
+                if (!string.IsNullOrEmpty(issue.file))
+                    writer.WriteLine($"  {issue.file}({issue.line}): {issue.message}");
+                else
+                    writer.WriteLine($"  {issue.message}");
+            }
+        }
+
+        protected override ValueTask<CompilePlayerResponse> ExecuteAsync(CompilePlayerRequest request)
+        {
+            var target = ResolveTarget(request.target);
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(target);
+
+            var settings = new ScriptCompilationSettings
+            {
+                target = target,
+                group = targetGroup,
+                extraScriptingDefines = request.extraScriptingDefines
+            };
+
+            var tempDir = Path.Combine(Path.GetTempPath(), $"unicli-compile-player-{Guid.NewGuid()}");
+            Directory.CreateDirectory(tempDir);
+
+            var errors = new List<CompileIssue>();
+            var warnings = new List<CompileIssue>();
+
+            void OnAssemblyCompilationFinished(string assemblyPath, CompilerMessage[] messages)
+            {
+                foreach (var msg in messages)
+                {
+                    var issue = new CompileIssue
+                    {
+                        message = msg.message,
+                        file = msg.file ?? "",
+                        line = msg.line
+                    };
+
+                    if (msg.type == CompilerMessageType.Error)
+                        errors.Add(issue);
+                    else if (msg.type == CompilerMessageType.Warning)
+                        warnings.Add(issue);
+                }
+            }
+
+            CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
+
+            ScriptCompilationResult result;
+            try
+            {
+                result = PlayerBuildInterface.CompilePlayerScripts(settings, tempDir);
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new CompileIssue { message = ex.Message, file = "", line = 0 });
+                result = default;
+            }
+            finally
+            {
+                CompilationPipeline.assemblyCompilationFinished -= OnAssemblyCompilationFinished;
+
+                try { Directory.Delete(tempDir, true); }
+                catch { /* best-effort cleanup */ }
+            }
+
+            var assemblies = result.assemblies != null
+                ? new List<string>(result.assemblies).ToArray()
+                : Array.Empty<string>();
+            var response = new CompilePlayerResponse
+            {
+                target = target.ToString(),
+                targetGroup = targetGroup.ToString(),
+                assemblyCount = assemblies.Length,
+                assemblies = assemblies,
+                errorCount = errors.Count,
+                warningCount = warnings.Count,
+                errors = errors.ToArray(),
+                warnings = warnings.ToArray()
+            };
+
+            if (errors.Count > 0)
+                throw new CommandFailedException($"Player compilation failed for {target} with {errors.Count} error(s)", response);
+
+            return new ValueTask<CompilePlayerResponse>(response);
+        }
+
+        private static BuildTarget ResolveTarget(string target)
+        {
+            if (string.IsNullOrEmpty(target))
+                return EditorUserBuildSettings.activeBuildTarget;
+
+            if (Enum.TryParse<BuildTarget>(target, true, out var parsed))
+                return parsed;
+
+            throw new ArgumentException($"Invalid build target: '{target}'. Use a valid BuildTarget name (e.g. Android, iOS, StandaloneWindows64).");
+        }
+    }
+
+    [Serializable]
+    public class CompilePlayerRequest
+    {
+        public string target = "";
+        public string[] extraScriptingDefines;
+    }
+
+    [Serializable]
+    public class CompilePlayerResponse
+    {
+        public string target;
+        public string targetGroup;
+        public int assemblyCount;
+        public string[] assemblies;
+        public int errorCount;
+        public int warningCount;
+        public CompileIssue[] errors;
+        public CompileIssue[] warnings;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/CompilePlayerHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/CompilePlayerHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c11ad50700034355bc7d04717d25e80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -3,6 +3,7 @@ namespace UniCli.Server.Editor
     public static class CommandNames
     {
         public const string Compile = "Compile";
+        public const string CompilePlayer = "CompilePlayer";
         public const string Search = "Search";
 
         public static class Console


### PR DESCRIPTION
## Summary

- Add `CompilePlayer` command that compiles player scripts for a specific build target via `PlayerBuildInterface.CompilePlayerScripts`
- Enables early detection of platform-specific compile errors (e.g. `UNITY_EDITOR`-only API usage) without a full player build
- Update documentation (README.md, SKILL.md, CLAUDE.md)

## Test plan

- [x] Unity editor compilation passes (`Compile`)
- [x] EditMode tests pass (8/8)
- [x] `CompilePlayer` appears in `commands` list
- [x] `CompilePlayer` succeeds with active build target
- [x] `CompilePlayer` correctly detects platform-specific compile errors (verified with intentional `UNITY_EDITOR`-only code)