### PR TITLE
Add PackageManager.GetInfo and PackageManager.Update commands

### DIFF
--- a/.claude-plugin/unicli/skills/unicli/SKILL.md
+++ b/.claude-plugin/unicli/skills/unicli/SKILL.md
@@ -95,6 +95,8 @@ unicli exec GameObject.Find --includeInactive
 | `PackageManager.Add` | Add a package |
 | `PackageManager.Remove` | Remove a package |
 | `PackageManager.Search` | Search the Unity package registry |
+| `PackageManager.GetInfo` | Get detailed info about an installed package |
+| `PackageManager.Update` | Update a package to a specific or latest version |
 | `AssemblyDefinition.List` | List assembly definitions |
 | `AssemblyDefinition.Get` | Get assembly definition details |
 | `AssemblyDefinition.Create` | Create a new assembly definition |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,11 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Save '{"all":true}' --j
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Close '{"name":"Additive"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.New '{"empty":true,"additive":true}' --json
 
+# PackageManager operations
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec PackageManager.GetInfo '{"name":"com.unity.test-framework"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec PackageManager.Update '{"name":"com.unity.test-framework"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec PackageManager.Update '{"name":"com.unity.test-framework","version":"1.4.5"}' --json
+
 # AssetDatabase operations
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Delete '{"path":"Assets/Prefabs/Old.prefab"}' --json
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ unicli exec AssetDatabase.Delete --path "Assets/Prefabs/Old.prefab"
 unicli exec PackageManager.List
 unicli exec PackageManager.Add --packageIdOrName com.unity.mathematics
 unicli exec PackageManager.Remove --packageIdOrName com.unity.mathematics
+unicli exec PackageManager.GetInfo --name com.unity.test-framework
+unicli exec PackageManager.Update --name com.unity.test-framework
+unicli exec PackageManager.Update --name com.unity.test-framework --version 1.4.5
 
 # Scene operations
 unicli exec Scene.List
@@ -213,6 +216,8 @@ The following commands are built in. You can also run `unicli commands` to see t
 | PackageManager     | `PackageManager.Add`                 | Add a package                      |
 | PackageManager     | `PackageManager.Remove`              | Remove a package                   |
 | PackageManager     | `PackageManager.Search`              | Search registry                    |
+| PackageManager     | `PackageManager.GetInfo`             | Get package details                |
+| PackageManager     | `PackageManager.Update`              | Update a package                   |
 | AssemblyDefinition | `AssemblyDefinition.List`            | List assembly definitions          |
 | AssemblyDefinition | `AssemblyDefinition.Get`             | Get assembly definition            |
 | AssemblyDefinition | `AssemblyDefinition.Create`          | Create assembly definition         |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerGetInfoHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerGetInfoHandler.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using UniCli.Server.Editor;
+using UnityEditor.PackageManager;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PackageManagerGetInfoHandler : CommandHandler<PackageManagerGetInfoRequest, PackageManagerGetInfoResponse>
+    {
+        public override string CommandName => CommandNames.PackageManager.GetInfo;
+        public override string Description => "Get detailed information about a specific installed package";
+
+        protected override bool TryWriteFormatted(PackageManagerGetInfoResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success)
+            {
+                writer.WriteLine("Failed to get package info");
+                return true;
+            }
+
+            writer.WriteLine($"Name:              {response.name}");
+            writer.WriteLine($"Display Name:      {response.displayName}");
+            writer.WriteLine($"Version:           {response.version}");
+            writer.WriteLine($"Latest Version:    {response.latestVersion}");
+            writer.WriteLine($"Source:            {response.source}");
+            writer.WriteLine($"Direct Dependency: {(response.isDirectDependency ? "yes" : "no")}");
+            writer.WriteLine($"Description:       {response.description}");
+
+            if (response.dependencies != null && response.dependencies.Length > 0)
+            {
+                writer.WriteLine("Dependencies:");
+                foreach (var dep in response.dependencies)
+                    writer.WriteLine($"  - {dep}");
+            }
+
+            return true;
+        }
+
+        protected override async ValueTask<PackageManagerGetInfoResponse> ExecuteAsync(PackageManagerGetInfoRequest request)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            var listRequest = Client.List(true);
+            await PackageManagerRequestHelper.WaitForCompletion(listRequest);
+
+            if (listRequest.Status == StatusCode.Failure)
+                throw new CommandFailedException(
+                    $"Package list failed: {listRequest.Error?.message ?? "Unknown error"}",
+                    new PackageManagerGetInfoResponse());
+
+            var packageInfo = listRequest.Result.FirstOrDefault(p => p.name == request.name);
+            if (packageInfo == null)
+                throw new CommandFailedException(
+                    $"Package '{request.name}' is not installed",
+                    new PackageManagerGetInfoResponse());
+
+            var dependencies = packageInfo.dependencies != null
+                ? packageInfo.dependencies.Select(d => $"{d.name}@{d.version}").ToArray()
+                : Array.Empty<string>();
+
+            return new PackageManagerGetInfoResponse
+            {
+                name = packageInfo.name,
+                displayName = packageInfo.displayName ?? "",
+                version = packageInfo.version,
+                source = packageInfo.source.ToString(),
+                description = packageInfo.description ?? "",
+                isDirectDependency = packageInfo.isDirectDependency,
+                latestVersion = packageInfo.versions.latest ?? packageInfo.version,
+                dependencies = dependencies
+            };
+        }
+    }
+
+    [Serializable]
+    public class PackageManagerGetInfoRequest
+    {
+        public string name;
+    }
+
+    [Serializable]
+    public class PackageManagerGetInfoResponse
+    {
+        public string name;
+        public string displayName;
+        public string version;
+        public string source;
+        public string description;
+        public bool isDirectDependency;
+        public string latestVersion;
+        public string[] dependencies;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerGetInfoHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerGetInfoHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cf1f04455596462eb8fc8a080139d5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerUpdateHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerUpdateHandler.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using UniCli.Server.Editor;
+using UnityEditor.PackageManager;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class PackageManagerUpdateHandler : CommandHandler<PackageManagerUpdateRequest, PackageManagerUpdateResponse>
+    {
+        public override string CommandName => CommandNames.PackageManager.Update;
+        public override string Description => "Update a package to a specific version or the latest version";
+
+        protected override bool TryWriteFormatted(PackageManagerUpdateResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Updated {response.name} {response.previousVersion} → {response.version}"
+                : "Failed to update package");
+            return true;
+        }
+
+        protected override async ValueTask<PackageManagerUpdateResponse> ExecuteAsync(PackageManagerUpdateRequest request)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            var listRequest = Client.List(true);
+            await PackageManagerRequestHelper.WaitForCompletion(listRequest);
+
+            if (listRequest.Status == StatusCode.Failure)
+                throw new CommandFailedException(
+                    $"Package list failed: {listRequest.Error?.message ?? "Unknown error"}",
+                    new PackageManagerUpdateResponse());
+
+            var currentPackage = listRequest.Result.FirstOrDefault(p => p.name == request.name);
+            if (currentPackage == null)
+                throw new CommandFailedException(
+                    $"Package '{request.name}' is not installed",
+                    new PackageManagerUpdateResponse());
+
+            var previousVersion = currentPackage.version;
+            var targetVersion = string.IsNullOrEmpty(request.version)
+                ? currentPackage.versions.latest ?? currentPackage.version
+                : request.version;
+
+            var identifier = $"{request.name}@{targetVersion}";
+            var addRequest = Client.Add(identifier);
+            await PackageManagerRequestHelper.WaitForCompletion(addRequest);
+
+            if (addRequest.Status == StatusCode.Failure)
+                throw new CommandFailedException(
+                    $"Package update failed: {addRequest.Error?.message ?? "Unknown error"}",
+                    new PackageManagerUpdateResponse
+                    {
+                        name = request.name,
+                        previousVersion = previousVersion
+                    });
+
+            var info = addRequest.Result;
+            return new PackageManagerUpdateResponse
+            {
+                name = info.name,
+                displayName = info.displayName ?? "",
+                previousVersion = previousVersion,
+                version = info.version,
+                source = info.source.ToString()
+            };
+        }
+    }
+
+    [Serializable]
+    public class PackageManagerUpdateRequest
+    {
+        public string name;
+        public string version;
+    }
+
+    [Serializable]
+    public class PackageManagerUpdateResponse
+    {
+        public string name;
+        public string displayName;
+        public string previousVersion;
+        public string version;
+        public string source;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerUpdateHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PackageManager/PackageManagerUpdateHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 966b7eecbfda2433e85c01997520350b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -60,6 +60,8 @@ namespace UniCli.Server.Editor
             public const string Add = "PackageManager.Add";
             public const string Remove = "PackageManager.Remove";
             public const string Search = "PackageManager.Search";
+            public const string GetInfo = "PackageManager.GetInfo";
+            public const string Update = "PackageManager.Update";
         }
 
         public static class Prefab


### PR DESCRIPTION
## Summary
- Add `PackageManager.GetInfo` command to retrieve detailed package information (version, dependencies, latest available version, etc.)
- Add `PackageManager.Update` command to update a package to a specific or the latest version
- Update documentation (README.md, SKILL.md, CLAUDE.md)

## Test plan
- [x] Client build succeeds with `dotnet build`
- [x] Unity server-side compilation succeeds with `exec Compile` (0 errors, 0 warnings)
- [x] All EditMode tests pass (8/8) with `TestRunner.RunEditMode`
- [x] `PackageManager.GetInfo` works correctly in both JSON and formatted output
- [x] `PackageManager.Update` works correctly in both JSON and formatted output