### PR TITLE
Add asset import and compilation guidelines to skill docs

### DIFF
--- a/.claude-plugin/unicli/skills/unicli/SKILL.md
+++ b/.claude-plugin/unicli/skills/unicli/SKILL.md
@@ -7,6 +7,31 @@ description: Use UniCli CLI to control Unity Editor — compile scripts, run tes
 UniCli lets you interact with Unity Editor directly from the terminal.
 The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the Editor must be open with the `com.yucchiy.unicli-server` package installed.
 
+## IMPORTANT: .meta file generation
+
+**You MUST run `AssetDatabase.Import` after creating or modifying any file under the Unity project's `Assets/` or `Packages/` directories.** Unity requires a `.meta` file for every asset, and these are generated automatically by `AssetDatabase.Import`. Failing to do so will cause missing references, broken imports, and compilation errors.
+
+```bash
+unicli exec AssetDatabase.Import --path "Assets/path/to/file.cs" --json
+```
+
+This rule applies to all file types: `.cs`, `.asmdef`, `.asset`, `.prefab`, directories, etc. Always import immediately after file creation or modification.
+
+## Recommended: Compilation verification
+
+After modifying C# code in the Unity project, it is recommended to verify that the code compiles successfully using `Compile`. This catches errors that `dotnet build` (client-side only) cannot detect, since server-side code is compiled by Unity's own compiler.
+
+```bash
+unicli exec Compile --json
+```
+
+If the project targets a specific platform (e.g., Android, iOS), `BuildPlayer.Compile` can also verify that the player scripts compile for that target. This catches platform-specific errors such as missing `#if` guards or unsupported API usage.
+
+```bash
+unicli exec BuildPlayer.Compile --json
+unicli exec BuildPlayer.Compile --target Android --json
+```
+
 ## Prerequisites
 
 Before running commands, verify that the CLI is installed and the Editor is reachable:


### PR DESCRIPTION
## Summary

- Add mandatory `.meta` file generation rule: always run `AssetDatabase.Import` after creating or modifying files under `Assets/` or `Packages/`
- Add recommended compilation verification guideline: use `Compile` to catch Unity-side errors and `BuildPlayer.Compile` for platform-specific checks

## Test plan

- [x] Verify SKILL.md renders correctly