### PR TITLE
Add ACK mechanism and concurrent connection support

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -104,5 +104,6 @@ namespace UniCli.Server.Editor
             public const string Connect = "Connection.Connect";
             public const string Status = "Connection.Status";
         }
+
     }
 }


### PR DESCRIPTION
## Summary

- **Two-phase timeout on client**: `--timeout` now only applies to sending the request and receiving the server ACK. After ACK, the client waits indefinitely for the response, preventing timeouts on long-running commands like `Compile`
- **Concurrent connection acceptance on server**: `AcceptClientAsync` no longer blocks on `HandleClientAsync`, allowing multiple clients to connect simultaneously. A `SemaphoreSlim(1,1)` serializes command processing while keeping connections alive
- **ACK protocol**: Server sends a 1-byte ACK (`0x01`) immediately after reading the request, before acquiring the semaphore. This lets the client know the request was received even if the server is busy processing another command
- **Unlimited pipe instances**: Changed `maxNumberOfServerInstances` from 10 to `MaxAllowedServerInstances` to support many concurrent connections
- **Graceful client disconnect handling**: `IOException` during response write is caught and logged as warning instead of error

## Protocol change

```
Before:
  Client → Server: [4-byte length][JSON request]
  Server → Client: [4-byte length][JSON response]

After:
  Client → Server: [4-byte length][JSON request]
  Server → Client: [1-byte ACK = 0x01]              ← NEW
  Server → Client: [4-byte length][JSON response]
```

## Test plan

- [x] `exec Compile --json` succeeds
- [x] `commands --json` succeeds
- [x] `exec Compile --timeout 1000 --json` succeeds (short timeout, long command — ACK prevents timeout)
- [x] 8 concurrent commands all succeed
- [x] 100 concurrent lightweight commands all succeed (0 failures)
- [x] 3x concurrent `Debug.Sleep(3s)` complete sequentially in ~9s (confirms semaphore serialization)
- [x] Unity Console shows 0 errors after stress tests
- [x] `TestRunner.RunEditMode` — all 8 tests pass