### PR TITLE
Add ACK protocol and handshake for pipe communication

### DIFF
--- a/src/UniCli.Client/Protocol/ProtocolConstants.cs
+++ b/src/UniCli.Client/Protocol/ProtocolConstants.cs
@@ -1,0 +1,9 @@
+namespace UniCli.Protocol
+{
+    public static class ProtocolConstants
+    {
+        public static readonly byte[] MagicBytes = { 0x55, 0x43, 0x4C, 0x49 }; // "UCLI"
+        public const ushort ProtocolVersion = 1;
+        public const int HandshakeSize = 6; // 4 (magic) + 2 (version)
+    }
+}

--- a/src/UniCli.Protocol/ProtocolConstants.cs
+++ b/src/UniCli.Protocol/ProtocolConstants.cs
@@ -1,0 +1,9 @@
+namespace UniCli.Protocol
+{
+    public static class ProtocolConstants
+    {
+        public static readonly byte[] MagicBytes = { 0x55, 0x43, 0x4C, 0x49 }; // "UCLI"
+        public const ushort ProtocolVersion = 1;
+        public const int HandshakeSize = 6; // 4 (magic) + 2 (version)
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/ProtocolConstants.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/ProtocolConstants.cs
@@ -1,0 +1,9 @@
+namespace UniCli.Protocol
+{
+    public static class ProtocolConstants
+    {
+        public static readonly byte[] MagicBytes = { 0x55, 0x43, 0x4C, 0x49 }; // "UCLI"
+        public const ushort ProtocolVersion = 1;
+        public const int HandshakeSize = 6; // 4 (magic) + 2 (version)
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/ProtocolConstants.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/ProtocolConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05f9ceeedf9d24faaa62197fd139a33f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add ACK mechanism so the client knows the server received the request before waiting for the (potentially long-running) response
- Support concurrent connections via `MaxAllowedServerInstances` and a per-connection command semaphore
- Add a 6-byte handshake phase (magic `"UCLI"` + protocol version) at connection time to detect client/server version mismatches early with clear error messages

## Protocol

```
Client → Server: [4 bytes "UCLI"][2 bytes version (uint16 LE)]
Server → Client: [4 bytes "UCLI"][2 bytes version (uint16 LE)]
-- handshake complete, enter command loop --
Client → Server: [4 bytes length][JSON request]
Server → Client: [1 byte ACK 0x01]
Server → Client: [4 bytes length][JSON response]
```

## Test plan
- [x] `dotnet build src/UniCli.Protocol` — Protocol builds and copies to Client/Server
- [x] `dotnet publish src/UniCli.Client -o .build` — Client publishes successfully
- [x] `exec Compile` — Unity compiles with zero errors
- [x] `commands` — Lists all 618 commands
- [x] Various commands (`GameObject.Find`, `Scene.*`, `EditorSettings.Inspect`, `Connection.Status`, `TypeCache.List`, `Project.Inspect`)
- [x] EditMode tests — 8/8 passed
- [x] PlayMode tests — passed (0 test cases defined)
- [x] Stress test: 10 rapid sequential commands — 10/10 success
- [x] Stress test: 5 parallel concurrent connections — 5/5 success
- [x] Stress test: 10 parallel mixed commands — all success