### PR TITLE
Add GameObject and Component manipulation commands

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -16,7 +16,7 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 
 ## RULES — Always Follow These
 
-1. **After creating/modifying ANY file under `Assets/` or `Packages/`**: Run `unicli exec AssetDatabase.Import --path "<path>" --json`. Unity requires `.meta` files for every asset — skipping this causes missing references, broken imports, and compilation errors. This applies to all file types: `.cs`, `.asmdef`, `.asset`, `.prefab`, directories, etc.
+1. **After creating/modifying ANY file under `Assets/` or `Packages/`**: Run `unicli exec AssetDatabase.Import --path "<path>" --json` to generate `.meta` files. **Never create `.meta` files manually** — always let Unity generate them via this command. Unity requires `.meta` files for every asset — skipping this causes missing references, broken imports, and compilation errors. This applies to all file types: `.cs`, `.asmdef`, `.asset`, `.prefab`, directories, etc.
 2. **After modifying C# code in the Unity project**: Run `unicli exec Compile --json` to verify compilation. `dotnet build` only checks the client side — server-side code is compiled by Unity's own compiler.
 3. **Always use `--json`** when parsing output programmatically.
 4. **If connection to Unity Editor fails**: Retry 2–3 times, then ask the user to confirm Unity Editor is running with the project open.
@@ -101,11 +101,19 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `TestRunner.RunEditMode` | Run EditMode tests |
 | `TestRunner.RunPlayMode` | Run PlayMode tests |
 | `GameObject.Find` | Find GameObjects by name, tag, or layer |
+| `GameObject.Create` | Create a new GameObject in the scene |
+| `GameObject.CreatePrimitive` | Create a primitive (Cube, Sphere, etc.) |
 | `GameObject.GetComponents` | Get components on a GameObject |
 | `GameObject.SetActive` | Set active state |
 | `GameObject.GetHierarchy` | Get scene hierarchy tree |
 | `GameObject.AddComponent` | Add a component to a GameObject |
 | `GameObject.RemoveComponent` | Remove a component from a GameObject |
+| `GameObject.Destroy` | Destroy a GameObject from the scene |
+| `GameObject.SetTransform` | Set local position/rotation/scale |
+| `GameObject.Duplicate` | Duplicate a GameObject |
+| `GameObject.Rename` | Rename a GameObject |
+| `GameObject.SetParent` | Change parent or move to root |
+| `Component.SetProperty` | Set a component property via SerializedProperty |
 | `Prefab.GetStatus` | Get prefab instance status |
 | `Prefab.Instantiate` | Instantiate a prefab into scene |
 | `Prefab.Save` | Save GameObject as prefab asset |
@@ -200,11 +208,32 @@ unicli exec GameObject.Find --name "Main Camera" --json
 unicli exec GameObject.GetComponents --instanceId 1234 --json
 ```
 
+**Create GameObjects:**
+
+```bash
+unicli exec GameObject.Create --name "Enemy" --json
+unicli exec GameObject.Create --name "Child" --parent "Enemy" --json
+unicli exec GameObject.Create --name "WithCollider" --components BoxCollider --json
+unicli exec GameObject.CreatePrimitive --primitiveType Cube --json
+unicli exec GameObject.CreatePrimitive --primitiveType Sphere --name "Ball" --json
+```
+
+**Modify GameObjects:**
+
+```bash
+unicli exec GameObject.Rename --path "Enemy" --name "Boss" --json
+unicli exec GameObject.SetTransform --path "Boss" --position 1,2,3 --json
+unicli exec GameObject.Duplicate --path "Boss" --json
+unicli exec GameObject.SetParent --path "Child" --parentPath "Boss" --json
+unicli exec GameObject.Destroy --path "OldObject" --json
+```
+
 **Manage components:**
 
 ```bash
 unicli exec GameObject.AddComponent --path "Player" --typeName BoxCollider --json
 unicli exec GameObject.RemoveComponent --componentInstanceId 1234 --json
+unicli exec Component.SetProperty --componentInstanceId 1234 --propertyPath "m_IsKinematic" --value "true" --json
 ```
 
 **Prefab operations:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,22 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli commands --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 
 # GameObject operations
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Create '{"name":"TestObject"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Create '{"name":"Child","parent":"TestObject"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Create '{"name":"WithCollider","components":["BoxCollider"]}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.CreatePrimitive '{"primitiveType":"Cube"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.CreatePrimitive '{"primitiveType":"Sphere","name":"Ball","parent":"Parent"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.GetComponents '{"path":"Main Camera"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.AddComponent '{"path":"Main Camera","typeName":"BoxCollider"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.RemoveComponent '{"componentInstanceId":12345}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Destroy '{"path":"TestObject"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.SetTransform '{"path":"TestObject","position":[1,2,3]}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Duplicate '{"path":"TestObject"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.Rename '{"path":"TestObject","name":"Renamed"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec GameObject.SetParent '{"path":"Child","parentPath":"Parent"}' --json
+
+# Component operations
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Component.SetProperty '{"componentInstanceId":12345,"propertyPath":"m_IsKinematic","value":"true"}' --json
 
 # Prefab operations
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.GetStatus '{"path":"Main Camera"}' --json

--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ unicli exec GameObject.GetComponents --instanceId 1234
 unicli exec GameObject.AddComponent --path "Player" --typeName BoxCollider
 unicli exec GameObject.RemoveComponent --componentInstanceId 1234
 
+# Create GameObjects
+unicli exec GameObject.Create --name "Enemy"
+unicli exec GameObject.Create --name "Child" --parent "Enemy"
+unicli exec GameObject.Create --name "WithCollider" --components BoxCollider
+unicli exec GameObject.CreatePrimitive --primitiveType Cube
+unicli exec GameObject.CreatePrimitive --primitiveType Sphere --name "Ball" --parent "Enemy"
+
+# Modify GameObjects
+unicli exec GameObject.Rename --path "Enemy" --name "Boss"
+unicli exec GameObject.SetTransform --path "Boss" --position 1,2,3 --rotation 0,90,0
+unicli exec GameObject.Duplicate --path "Boss"
+unicli exec GameObject.SetParent --path "Boss(Clone)" --parentPath "Boss"
+unicli exec GameObject.Destroy --path "Boss(Clone)"
+
+# Set component properties
+unicli exec Component.SetProperty --componentInstanceId 1234 --propertyPath "m_IsKinematic" --value "true"
+
 # Prefab operations
 unicli exec Prefab.GetStatus --path "MyPrefabInstance"
 unicli exec Prefab.Instantiate --assetPath "Assets/Prefabs/Enemy.prefab"
@@ -232,11 +249,19 @@ The following commands are built in. You can also run `unicli commands` to see t
 | TestRunner         | `TestRunner.RunEditMode`             | Run EditMode tests                 |
 | TestRunner         | `TestRunner.RunPlayMode`             | Run PlayMode tests                 |
 | GameObject         | `GameObject.Find`                    | Find GameObjects                   |
+| GameObject         | `GameObject.Create`                  | Create a new GameObject            |
+| GameObject         | `GameObject.CreatePrimitive`         | Create a primitive GameObject      |
 | GameObject         | `GameObject.GetComponents`           | Get components                     |
 | GameObject         | `GameObject.SetActive`               | Set active state                   |
 | GameObject         | `GameObject.GetHierarchy`            | Get scene hierarchy                |
 | GameObject         | `GameObject.AddComponent`            | Add a component                    |
 | GameObject         | `GameObject.RemoveComponent`         | Remove a component                 |
+| GameObject         | `GameObject.Destroy`                 | Destroy a GameObject               |
+| GameObject         | `GameObject.SetTransform`            | Set local transform                |
+| GameObject         | `GameObject.Duplicate`               | Duplicate a GameObject             |
+| GameObject         | `GameObject.Rename`                  | Rename a GameObject                |
+| GameObject         | `GameObject.SetParent`               | Change parent or move to root      |
+| Component          | `Component.SetProperty`              | Set a component property           |
 | Prefab             | `Prefab.GetStatus`                   | Get prefab instance status         |
 | Prefab             | `Prefab.Instantiate`                 | Instantiate a prefab into scene    |
 | Prefab             | `Prefab.Save`                        | Save GameObject as prefab          |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/GameObjectResolver.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/GameObjectResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -6,6 +7,20 @@ namespace UniCli.Server.Editor
 {
     internal static class GameObjectResolver
     {
+        public static string BuildPath(Transform transform)
+        {
+            var parts = new List<string>();
+            var current = transform;
+            while (current != null)
+            {
+                parts.Add(current.name);
+                current = current.parent;
+            }
+
+            parts.Reverse();
+            return string.Join("/", parts);
+        }
+
         public static GameObject Resolve(int instanceId, string path)
         {
             if (instanceId != 0)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2098097f5e07403ab5baa060a23bed87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component/SetPropertyHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component/SetPropertyHandler.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SetPropertyHandler : CommandHandler<SetPropertyRequest, SetPropertyResponse>
+    {
+        public override string CommandName => CommandNames.Component.SetProperty;
+        public override string Description => "Set a component property value via SerializedProperty";
+
+        protected override bool TryWriteFormatted(SetPropertyResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Set {response.propertyPath} = {response.currentValue} (was {response.previousValue})");
+            else
+                writer.WriteLine("Failed to set property");
+
+            return true;
+        }
+
+        protected override ValueTask<SetPropertyResponse> ExecuteAsync(SetPropertyRequest request)
+        {
+            if (request.componentInstanceId == 0)
+                throw new ArgumentException("componentInstanceId is required");
+            if (string.IsNullOrEmpty(request.propertyPath))
+                throw new ArgumentException("propertyPath is required");
+
+            var obj = EditorUtility.InstanceIDToObject(request.componentInstanceId);
+            if (obj is not UnityEngine.Component component)
+            {
+                throw new CommandFailedException(
+                    $"Component not found for instanceId={request.componentInstanceId}",
+                    new SetPropertyResponse());
+            }
+
+            using var serializedObject = new SerializedObject(component);
+            var property = serializedObject.FindProperty(request.propertyPath);
+            if (property == null)
+            {
+                throw new CommandFailedException(
+                    $"Property \"{request.propertyPath}\" not found on {component.GetType().FullName}",
+                    new SetPropertyResponse());
+            }
+
+            var previousValue = GetPropertyValueString(property);
+            SetPropertyValue(property, request.value);
+            serializedObject.ApplyModifiedProperties();
+
+            var verifyProperty = serializedObject.FindProperty(request.propertyPath);
+            var currentValue = GetPropertyValueString(verifyProperty);
+
+            return new ValueTask<SetPropertyResponse>(new SetPropertyResponse
+            {
+                componentInstanceId = request.componentInstanceId,
+                propertyPath = request.propertyPath,
+                previousValue = previousValue,
+                currentValue = currentValue
+            });
+        }
+
+        private static void SetPropertyValue(SerializedProperty property, string value)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    property.intValue = int.Parse(value, CultureInfo.InvariantCulture);
+                    break;
+                case SerializedPropertyType.Float:
+                    property.floatValue = float.Parse(value, CultureInfo.InvariantCulture);
+                    break;
+                case SerializedPropertyType.Boolean:
+                    property.boolValue = bool.Parse(value);
+                    break;
+                case SerializedPropertyType.String:
+                    property.stringValue = value;
+                    break;
+                case SerializedPropertyType.Enum:
+                    if (int.TryParse(value, out var enumIndex))
+                    {
+                        property.enumValueIndex = enumIndex;
+                    }
+                    else
+                    {
+                        var index = Array.IndexOf(property.enumNames, value);
+                        if (index < 0)
+                            throw new CommandFailedException(
+                                $"Invalid enum value \"{value}\". Valid values: {string.Join(", ", property.enumNames)}",
+                                new SetPropertyResponse());
+                        property.enumValueIndex = index;
+                    }
+                    break;
+                case SerializedPropertyType.Vector2:
+                    property.vector2Value = ParseVector2(value);
+                    break;
+                case SerializedPropertyType.Vector3:
+                    property.vector3Value = ParseVector3(value);
+                    break;
+                case SerializedPropertyType.Vector4:
+                    property.vector4Value = ParseVector4(value);
+                    break;
+                case SerializedPropertyType.Color:
+                    property.colorValue = ParseColor(value);
+                    break;
+                default:
+                    throw new CommandFailedException(
+                        $"Unsupported property type: {property.propertyType}",
+                        new SetPropertyResponse());
+            }
+        }
+
+        private static Vector2 ParseVector2(string value)
+        {
+            var parts = value.Split(',');
+            if (parts.Length != 2)
+                throw new CommandFailedException("Vector2 requires 2 comma-separated values (e.g. \"1.0,2.0\")", new SetPropertyResponse());
+            return new Vector2(
+                float.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[1].Trim(), CultureInfo.InvariantCulture));
+        }
+
+        private static Vector3 ParseVector3(string value)
+        {
+            var parts = value.Split(',');
+            if (parts.Length != 3)
+                throw new CommandFailedException("Vector3 requires 3 comma-separated values (e.g. \"1.0,2.0,3.0\")", new SetPropertyResponse());
+            return new Vector3(
+                float.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[2].Trim(), CultureInfo.InvariantCulture));
+        }
+
+        private static Vector4 ParseVector4(string value)
+        {
+            var parts = value.Split(',');
+            if (parts.Length != 4)
+                throw new CommandFailedException("Vector4 requires 4 comma-separated values (e.g. \"1.0,2.0,3.0,4.0\")", new SetPropertyResponse());
+            return new Vector4(
+                float.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[2].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[3].Trim(), CultureInfo.InvariantCulture));
+        }
+
+        private static Color ParseColor(string value)
+        {
+            var parts = value.Split(',');
+            if (parts.Length < 3 || parts.Length > 4)
+                throw new CommandFailedException("Color requires 3-4 comma-separated values (e.g. \"1.0,0.5,0.0\" or \"1.0,0.5,0.0,1.0\")", new SetPropertyResponse());
+            return new Color(
+                float.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[1].Trim(), CultureInfo.InvariantCulture),
+                float.Parse(parts[2].Trim(), CultureInfo.InvariantCulture),
+                parts.Length == 4 ? float.Parse(parts[3].Trim(), CultureInfo.InvariantCulture) : 1f);
+        }
+
+        private static string GetPropertyValueString(SerializedProperty property)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    return property.intValue.ToString();
+                case SerializedPropertyType.Boolean:
+                    return property.boolValue.ToString().ToLowerInvariant();
+                case SerializedPropertyType.Float:
+                    return property.floatValue.ToString("G");
+                case SerializedPropertyType.String:
+                    return property.stringValue ?? "";
+                case SerializedPropertyType.Enum:
+                    return property.enumNames.Length > property.enumValueIndex && property.enumValueIndex >= 0
+                        ? property.enumNames[property.enumValueIndex]
+                        : property.enumValueIndex.ToString();
+                case SerializedPropertyType.ObjectReference:
+                    return property.objectReferenceValue != null
+                        ? property.objectReferenceValue.name
+                        : "(null)";
+                case SerializedPropertyType.Vector2:
+                    return property.vector2Value.ToString();
+                case SerializedPropertyType.Vector3:
+                    return property.vector3Value.ToString();
+                case SerializedPropertyType.Vector4:
+                    return property.vector4Value.ToString();
+                case SerializedPropertyType.Color:
+                    return property.colorValue.ToString();
+                default:
+                    return $"({property.propertyType})";
+            }
+        }
+    }
+
+    [Serializable]
+    public class SetPropertyRequest
+    {
+        public int componentInstanceId;
+        public string propertyPath = "";
+        public string value = "";
+    }
+
+    [Serializable]
+    public class SetPropertyResponse
+    {
+        public int componentInstanceId;
+        public string propertyPath;
+        public string previousValue;
+        public string currentValue;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component/SetPropertyHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Component/SetPropertyHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 590791decc3d4575874256ad8f3f8d09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreateGameObjectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreateGameObjectHandler.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class CreateGameObjectHandler : CommandHandler<CreateGameObjectRequest, CreateGameObjectResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.Create;
+        public override string Description => "Create a new GameObject in the scene";
+
+        protected override bool TryWriteFormatted(CreateGameObjectResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Created GameObject \"{response.name}\" (instanceId={response.instanceId})");
+            else
+                writer.WriteLine("Failed to create GameObject");
+
+            return true;
+        }
+
+        protected override ValueTask<CreateGameObjectResponse> ExecuteAsync(CreateGameObjectRequest request)
+        {
+            var name = string.IsNullOrEmpty(request.name) ? "GameObject" : request.name;
+
+            var go = new GameObject(name);
+            Undo.RegisterCreatedObjectUndo(go, $"Create {name}");
+
+            if (!string.IsNullOrEmpty(request.parent))
+            {
+                var parentGo = GameObjectResolver.Resolve(0, request.parent);
+                if (parentGo == null)
+                {
+                    UnityEngine.Object.DestroyImmediate(go);
+                    throw new CommandFailedException(
+                        $"Parent GameObject not found: \"{request.parent}\"",
+                        new CreateGameObjectResponse());
+                }
+
+                go.transform.SetParent(parentGo.transform, false);
+            }
+
+            if (request.components != null)
+            {
+                foreach (var typeName in request.components)
+                {
+                    if (string.IsNullOrEmpty(typeName)) continue;
+
+                    var componentType = ResolveComponentType(typeName);
+                    var component = go.AddComponent(componentType);
+                    if (component == null)
+                    {
+                        throw new CommandFailedException(
+                            $"Failed to add component {componentType.FullName} to {go.name}",
+                            new CreateGameObjectResponse());
+                    }
+                }
+            }
+
+            var components = go.GetComponents<Component>();
+            var componentNames = new List<string>(components.Length);
+            foreach (var component in components)
+            {
+                if (component != null)
+                    componentNames.Add(component.GetType().FullName);
+            }
+
+            var path = GameObjectResolver.BuildPath(go.transform);
+
+            return new ValueTask<CreateGameObjectResponse>(new CreateGameObjectResponse
+            {
+                instanceId = go.GetInstanceID(),
+                name = go.name,
+                path = path,
+                isActive = go.activeSelf,
+                components = componentNames.ToArray()
+            });
+        }
+
+        private static Type ResolveComponentType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null && typeof(Component).IsAssignableFrom(type))
+                return type;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                type = assembly.GetType(typeName);
+                if (type != null && typeof(Component).IsAssignableFrom(type))
+                    return type;
+            }
+
+            if (!typeName.Contains("."))
+            {
+                var candidates = new List<Type>();
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    Type[] types;
+                    try
+                    {
+                        types = assembly.GetTypes();
+                    }
+                    catch (System.Reflection.ReflectionTypeLoadException e)
+                    {
+                        types = e.Types;
+                    }
+
+                    foreach (var t in types)
+                    {
+                        if (t != null && t.Name == typeName && typeof(Component).IsAssignableFrom(t))
+                            candidates.Add(t);
+                    }
+                }
+
+                if (candidates.Count == 1)
+                    return candidates[0];
+
+                if (candidates.Count > 1)
+                {
+                    throw new CommandFailedException(
+                        $"Ambiguous type name \"{typeName}\". Candidates: {candidates[0].FullName}, {candidates[1].FullName}",
+                        new CreateGameObjectResponse());
+                }
+            }
+
+            throw new CommandFailedException(
+                $"Component type \"{typeName}\" not found",
+                new CreateGameObjectResponse());
+        }
+    }
+
+    [Serializable]
+    public class CreateGameObjectRequest
+    {
+        public string name = "";
+        public string parent = "";
+        public string[] components;
+    }
+
+    [Serializable]
+    public class CreateGameObjectResponse
+    {
+        public int instanceId;
+        public string name;
+        public string path;
+        public bool isActive;
+        public string[] components;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreateGameObjectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreateGameObjectHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d065ddefd5fdb4330a2aa1787552b1ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreatePrimitiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreatePrimitiveHandler.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class CreatePrimitiveHandler : CommandHandler<CreatePrimitiveRequest, CreateGameObjectResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.CreatePrimitive;
+        public override string Description => "Create a primitive GameObject (Cube, Sphere, Capsule, Cylinder, Plane, Quad)";
+
+        protected override bool TryWriteFormatted(CreateGameObjectResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Created primitive \"{response.name}\" (instanceId={response.instanceId})");
+            else
+                writer.WriteLine("Failed to create primitive");
+
+            return true;
+        }
+
+        protected override ValueTask<CreateGameObjectResponse> ExecuteAsync(CreatePrimitiveRequest request)
+        {
+            if (string.IsNullOrEmpty(request.primitiveType))
+                throw new ArgumentException("primitiveType is required (Cube, Sphere, Capsule, Cylinder, Plane, Quad)");
+
+            if (!Enum.TryParse<PrimitiveType>(request.primitiveType, true, out var primitiveType))
+            {
+                throw new CommandFailedException(
+                    $"Invalid primitiveType \"{request.primitiveType}\". Valid values: Cube, Sphere, Capsule, Cylinder, Plane, Quad",
+                    new CreateGameObjectResponse());
+            }
+
+            var go = GameObject.CreatePrimitive(primitiveType);
+            Undo.RegisterCreatedObjectUndo(go, $"Create {primitiveType}");
+
+            if (!string.IsNullOrEmpty(request.name))
+                go.name = request.name;
+
+            if (!string.IsNullOrEmpty(request.parent))
+            {
+                var parentGo = GameObjectResolver.Resolve(0, request.parent);
+                if (parentGo == null)
+                {
+                    UnityEngine.Object.DestroyImmediate(go);
+                    throw new CommandFailedException(
+                        $"Parent GameObject not found: \"{request.parent}\"",
+                        new CreateGameObjectResponse());
+                }
+
+                go.transform.SetParent(parentGo.transform, false);
+            }
+
+            var components = go.GetComponents<Component>();
+            var componentNames = new List<string>(components.Length);
+            foreach (var component in components)
+            {
+                if (component != null)
+                    componentNames.Add(component.GetType().FullName);
+            }
+
+            return new ValueTask<CreateGameObjectResponse>(new CreateGameObjectResponse
+            {
+                instanceId = go.GetInstanceID(),
+                name = go.name,
+                path = GameObjectResolver.BuildPath(go.transform),
+                isActive = go.activeSelf,
+                components = componentNames.ToArray()
+            });
+        }
+    }
+
+    [Serializable]
+    public class CreatePrimitiveRequest
+    {
+        public string primitiveType = "";
+        public string name = "";
+        public string parent = "";
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreatePrimitiveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/CreatePrimitiveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6e0eb79e92942439db31ad66845d290
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DestroyGameObjectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DestroyGameObjectHandler.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class DestroyGameObjectHandler : CommandHandler<DestroyGameObjectRequest, DestroyGameObjectResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.Destroy;
+        public override string Description => "Destroy a GameObject from the scene";
+
+        protected override bool TryWriteFormatted(DestroyGameObjectResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Destroyed GameObject \"{response.name}\" (instanceId={response.instanceId})");
+            else
+                writer.WriteLine("Failed to destroy GameObject");
+
+            return true;
+        }
+
+        protected override ValueTask<DestroyGameObjectResponse> ExecuteAsync(DestroyGameObjectRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new DestroyGameObjectResponse());
+            }
+
+            var name = go.name;
+            var instanceId = go.GetInstanceID();
+
+            Undo.DestroyObjectImmediate(go);
+
+            return new ValueTask<DestroyGameObjectResponse>(new DestroyGameObjectResponse
+            {
+                name = name,
+                instanceId = instanceId
+            });
+        }
+    }
+
+    [Serializable]
+    public class DestroyGameObjectRequest
+    {
+        public int instanceId;
+        public string path = "";
+    }
+
+    [Serializable]
+    public class DestroyGameObjectResponse
+    {
+        public string name;
+        public int instanceId;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DestroyGameObjectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DestroyGameObjectHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ae704ff0e2649908e9521930415217b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DuplicateGameObjectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DuplicateGameObjectHandler.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class DuplicateGameObjectHandler : CommandHandler<DuplicateGameObjectRequest, CreateGameObjectResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.Duplicate;
+        public override string Description => "Duplicate an existing GameObject in the scene";
+
+        protected override bool TryWriteFormatted(CreateGameObjectResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Duplicated GameObject \"{response.name}\" (instanceId={response.instanceId})");
+            else
+                writer.WriteLine("Failed to duplicate GameObject");
+
+            return true;
+        }
+
+        protected override ValueTask<CreateGameObjectResponse> ExecuteAsync(DuplicateGameObjectRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new CreateGameObjectResponse());
+            }
+
+            var duplicate = UnityEngine.Object.Instantiate(go, go.transform.parent);
+            Undo.RegisterCreatedObjectUndo(duplicate, $"Duplicate {go.name}");
+
+            if (!string.IsNullOrEmpty(request.name))
+                duplicate.name = request.name;
+
+            var components = duplicate.GetComponents<Component>();
+            var componentNames = new List<string>(components.Length);
+            foreach (var component in components)
+            {
+                if (component != null)
+                    componentNames.Add(component.GetType().FullName);
+            }
+
+            return new ValueTask<CreateGameObjectResponse>(new CreateGameObjectResponse
+            {
+                instanceId = duplicate.GetInstanceID(),
+                name = duplicate.name,
+                path = GameObjectResolver.BuildPath(duplicate.transform),
+                isActive = duplicate.activeSelf,
+                components = componentNames.ToArray()
+            });
+        }
+    }
+
+    [Serializable]
+    public class DuplicateGameObjectRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public string name = "";
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DuplicateGameObjectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/DuplicateGameObjectHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b652709668224f5d88e384764e6ef118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/RenameGameObjectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/RenameGameObjectHandler.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class RenameGameObjectHandler : CommandHandler<RenameGameObjectRequest, RenameGameObjectResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.Rename;
+        public override string Description => "Rename a GameObject";
+
+        protected override bool TryWriteFormatted(RenameGameObjectResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Renamed \"{response.previousName}\" to \"{response.name}\"");
+            else
+                writer.WriteLine("Failed to rename GameObject");
+
+            return true;
+        }
+
+        protected override ValueTask<RenameGameObjectResponse> ExecuteAsync(RenameGameObjectRequest request)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new RenameGameObjectResponse());
+            }
+
+            var previousName = go.name;
+            Undo.RecordObject(go, $"Rename {previousName}");
+            go.name = request.name;
+
+            return new ValueTask<RenameGameObjectResponse>(new RenameGameObjectResponse
+            {
+                previousName = previousName,
+                name = go.name,
+                instanceId = go.GetInstanceID()
+            });
+        }
+    }
+
+    [Serializable]
+    public class RenameGameObjectRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public string name = "";
+    }
+
+    [Serializable]
+    public class RenameGameObjectResponse
+    {
+        public string previousName;
+        public string name;
+        public int instanceId;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/RenameGameObjectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/RenameGameObjectHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 635d547b671b45bba67875e8f5523435
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetParentHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetParentHandler.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SetParentHandler : CommandHandler<SetParentRequest, SetParentResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.SetParent;
+        public override string Description => "Change the parent of a GameObject (or move to root)";
+
+        protected override bool TryWriteFormatted(SetParentResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Moved \"{response.name}\" to \"{response.path}\"");
+            else
+                writer.WriteLine("Failed to set parent");
+
+            return true;
+        }
+
+        protected override ValueTask<SetParentResponse> ExecuteAsync(SetParentRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new SetParentResponse());
+            }
+
+            Transform newParent = null;
+            if (request.parentInstanceId != 0 || !string.IsNullOrEmpty(request.parentPath))
+            {
+                var parentGo = GameObjectResolver.Resolve(request.parentInstanceId, request.parentPath);
+                if (parentGo == null)
+                {
+                    throw new CommandFailedException(
+                        $"Parent GameObject not found (instanceId={request.parentInstanceId}, path=\"{request.parentPath}\")",
+                        new SetParentResponse());
+                }
+
+                newParent = parentGo.transform;
+            }
+
+            Undo.SetTransformParent(go.transform, newParent, $"Set Parent {go.name}");
+
+            if (!request.worldPositionStays)
+                go.transform.SetParent(newParent, false);
+
+            return new ValueTask<SetParentResponse>(new SetParentResponse
+            {
+                instanceId = go.GetInstanceID(),
+                name = go.name,
+                path = GameObjectResolver.BuildPath(go.transform)
+            });
+        }
+    }
+
+    [Serializable]
+    public class SetParentRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public int parentInstanceId;
+        public string parentPath = "";
+        public bool worldPositionStays = true;
+    }
+
+    [Serializable]
+    public class SetParentResponse
+    {
+        public int instanceId;
+        public string name;
+        public string path;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetParentHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetParentHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d68dc2dec6545f1997c438c13d4bc2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetTransformHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetTransformHandler.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class SetTransformHandler : CommandHandler<SetTransformRequest, SetTransformResponse>
+    {
+        public override string CommandName => CommandNames.GameObject.SetTransform;
+        public override string Description => "Set the local transform (position, rotation, scale) of a GameObject";
+
+        protected override bool TryWriteFormatted(SetTransformResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+                writer.WriteLine($"Updated transform of \"{response.name}\"");
+            else
+                writer.WriteLine("Failed to set transform");
+
+            return true;
+        }
+
+        protected override ValueTask<SetTransformResponse> ExecuteAsync(SetTransformRequest request)
+        {
+            var go = GameObjectResolver.Resolve(request.instanceId, request.path);
+            if (go == null)
+            {
+                throw new CommandFailedException(
+                    $"GameObject not found (instanceId={request.instanceId}, path=\"{request.path}\")",
+                    new SetTransformResponse());
+            }
+
+            var transform = go.transform;
+            Undo.RecordObject(transform, $"Set Transform {go.name}");
+
+            if (request.position != null && request.position.Length == 3)
+                transform.localPosition = new Vector3(request.position[0], request.position[1], request.position[2]);
+
+            if (request.rotation != null && request.rotation.Length == 3)
+                transform.localEulerAngles = new Vector3(request.rotation[0], request.rotation[1], request.rotation[2]);
+
+            if (request.localScale != null && request.localScale.Length == 3)
+                transform.localScale = new Vector3(request.localScale[0], request.localScale[1], request.localScale[2]);
+
+            return new ValueTask<SetTransformResponse>(new SetTransformResponse
+            {
+                instanceId = go.GetInstanceID(),
+                name = go.name,
+                position = new[] { transform.localPosition.x, transform.localPosition.y, transform.localPosition.z },
+                rotation = new[] { transform.localEulerAngles.x, transform.localEulerAngles.y, transform.localEulerAngles.z },
+                localScale = new[] { transform.localScale.x, transform.localScale.y, transform.localScale.z }
+            });
+        }
+    }
+
+    [Serializable]
+    public class SetTransformRequest
+    {
+        public int instanceId;
+        public string path = "";
+        public float[] position;
+        public float[] rotation;
+        public float[] localScale;
+    }
+
+    [Serializable]
+    public class SetTransformResponse
+    {
+        public int instanceId;
+        public string name;
+        public float[] position;
+        public float[] rotation;
+        public float[] localScale;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetTransformHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/SetTransformHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb38be8c8c7c4fd0a9edb8e67d89ae9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -39,11 +39,23 @@ namespace UniCli.Server.Editor
         public static class GameObject
         {
             public const string Find = "GameObject.Find";
+            public const string Create = "GameObject.Create";
             public const string GetComponents = "GameObject.GetComponents";
             public const string SetActive = "GameObject.SetActive";
             public const string GetHierarchy = "GameObject.GetHierarchy";
             public const string AddComponent = "GameObject.AddComponent";
             public const string RemoveComponent = "GameObject.RemoveComponent";
+            public const string Destroy = "GameObject.Destroy";
+            public const string SetTransform = "GameObject.SetTransform";
+            public const string Duplicate = "GameObject.Duplicate";
+            public const string Rename = "GameObject.Rename";
+            public const string SetParent = "GameObject.SetParent";
+            public const string CreatePrimitive = "GameObject.CreatePrimitive";
+        }
+
+        public static class Component
+        {
+            public const string SetProperty = "Component.SetProperty";
         }
 
         public static class AssetDatabase


### PR DESCRIPTION
## Summary
- Add 7 new commands for GameObject and Component manipulation:
  - `GameObject.Destroy` — Remove a GameObject from the scene
  - `GameObject.SetTransform` — Set local position/rotation/scale
  - `GameObject.Duplicate` — Duplicate an existing GameObject
  - `GameObject.Rename` — Rename a GameObject
  - `GameObject.SetParent` — Change parent or move to root
  - `GameObject.CreatePrimitive` — Create primitive shapes (Cube, Sphere, etc.)
  - `Component.SetProperty` — Set component properties via SerializedProperty
- Extract `BuildPath` to `GameObjectResolver` for reuse across handlers
- Update documentation (README, SKILL.md, CLAUDE.md)

## Test plan
- [x] Unity compilation passes with 0 errors
- [x] All EditMode tests pass (8/8)
- [x] Each new command verified manually (Create → Rename → SetTransform → Duplicate → SetParent → Destroy, CreatePrimitive, Component.SetProperty)