### PR TITLE
Release v0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor拡張機能 - CLIからUnityを操作するためのサーバー",
   "unity": "2022.3",


### PR DESCRIPTION
## Changelog

### New Features
- **PID file-based smart focus control** — The server writes a PID file (`Library/UniCli/server.pid`) on startup, enabling the CLI to automatically bring Unity Editor to the foreground only when the server is not responding (e.g., after an assembly reload). Focus is restored to the original application once the command completes. (#23)
- **`UNICLI_FOCUS` environment variable** — Set to `0` or `false` to globally disable auto-focus behavior.

### Improvements
- **Case-insensitive command matching** — `CommandDispatcher` now matches command names case-insensitively.
- **Simplified status command** — `unicli status` now reads PID from file and reports whether Unity is running without requiring a server connection.
- **Removed server-side focus handling** — Focus logic moved entirely to the client side, reducing server complexity.

### Other
- Added Homebrew installation instructions to README.
- Added GameObject/Component commands: Destroy, SetTransform, Duplicate, Rename, SetParent, CreatePrimitive, Component.SetProperty.