### PR TITLE
Refactor server lifecycle and consolidate status info

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CoreServiceInstaller.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CoreServiceInstaller.cs
@@ -5,6 +5,9 @@ namespace UniCli.Server.Editor
         public void Install(ServiceRegistry services)
         {
             services.AddSingleton(new EditorLogManager(maxBufferSize: 10000));
+
+            var pipeName = ProjectIdentifier.GetPipeName();
+            services.AddSingleton(new ServerContext(pipeName));
         }
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ProjectInfoHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ProjectInfoHandler.cs
@@ -9,18 +9,28 @@ namespace UniCli.Server.Editor.Handlers
 {
     public sealed class ProjectInfoHandler : CommandHandler<Unit, ProjectInfoResponse>
     {
+        private readonly ServerContext _context;
+
+        public ProjectInfoHandler(ServerContext context)
+        {
+            _context = context;
+        }
+
         public override string CommandName => CommandNames.Project.Inspect;
         public override string Description => "Get Unity project information";
 
         protected override bool TryWriteFormatted(ProjectInfoResponse response, bool success, IFormatWriter writer)
         {
-            writer.WriteLine($"Unity:   {response.unityVersion}");
-            writer.WriteLine($"Project: {response.productName}");
-            writer.WriteLine($"Company: {response.companyName}");
-            writer.WriteLine($"Path:    {response.projectPath}");
-            writer.WriteLine($"Target:  {response.buildTarget}");
-            writer.WriteLine($"Playing: {(response.isPlaying ? "Yes" : "No")}");
-            writer.WriteLine($"PID:     {response.processId}");
+            writer.WriteLine($"Unity:     {response.unityVersion}");
+            writer.WriteLine($"Project:   {response.productName}");
+            writer.WriteLine($"Company:   {response.companyName}");
+            writer.WriteLine($"Path:      {response.projectPath}");
+            writer.WriteLine($"Target:    {response.buildTarget}");
+            writer.WriteLine($"Playing:   {(response.isPlaying ? "Yes" : "No")}");
+            writer.WriteLine($"PID:       {response.processId}");
+            writer.WriteLine($"Server ID: {response.serverId}");
+            writer.WriteLine($"Started:   {response.startedAt}");
+            writer.WriteLine($"Uptime:    {response.uptimeSeconds:F1}s");
 
             return true;
         }
@@ -35,7 +45,10 @@ namespace UniCli.Server.Editor.Handlers
                 companyName = PlayerSettings.companyName,
                 buildTarget = EditorUserBuildSettings.activeBuildTarget.ToString(),
                 isPlaying = EditorApplication.isPlaying,
-                processId = Process.GetCurrentProcess().Id
+                processId = Process.GetCurrentProcess().Id,
+                serverId = _context.ServerId,
+                startedAt = _context.StartedAt.ToString("yyyy-MM-dd HH:mm:ss"),
+                uptimeSeconds = (DateTime.Now - _context.StartedAt).TotalSeconds
             };
 
             return new ValueTask<ProjectInfoResponse>(response);
@@ -52,5 +65,8 @@ namespace UniCli.Server.Editor.Handlers
         public string buildTarget;
         public bool isPlaying;
         public int processId;
+        public string serverId;
+        public string startedAt;
+        public double uptimeSeconds;
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -116,6 +116,5 @@ namespace UniCli.Server.Editor
             public const string Connect = "Connection.Connect";
             public const string Status = "Connection.Status";
         }
-
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServerContext.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServerContext.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System;
+
+namespace UniCli.Server.Editor
+{
+    public sealed class ServerContext
+    {
+        public string ServerId { get; }
+        public DateTime StartedAt { get; }
+        public string PipeName { get; }
+
+        public ServerContext(string pipeName)
+        {
+            ServerId = Guid.NewGuid().ToString("N")[..8];
+            StartedAt = DateTime.Now;
+            PipeName = pipeName;
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServerContext.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServerContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 069bec8f4311f45bc85297ccb9d61253
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
@@ -21,7 +21,13 @@ namespace UniCli.Server.Editor
         static UniCliServerBootstrap()
         {
             EnsurePidFile();
-            EditorApplication.delayCall += Initialize;
+            EditorApplication.update += InitializeOnce;
+        }
+
+        private static void InitializeOnce()
+        {
+            EditorApplication.update -= InitializeOnce;
+            Initialize();
         }
 
         private static void Initialize()
@@ -44,7 +50,6 @@ namespace UniCli.Server.Editor
             Application.runInBackground = true;
 
             var pipeName = ProjectIdentifier.GetPipeName();
-
             _dispatcher = new CommandDispatcher(Services);
             _server = new UniCliServer(
                 pipeName,


### PR DESCRIPTION
## Summary
- Introduce `ServerContext` to hold server identity (serverId, startedAt) and register it via `CoreServiceInstaller`
- Consolidate server status info into `Project.Inspect` response and `unicli status` output (serverId, startedAt, uptimeSeconds)
- Use `InitializeOnce` via `EditorApplication.update` instead of `delayCall` for more reliable server initialization
- Simplify `PipeServer` by removing command semaphore and reordering ACK
- Process commands sequentially via Task tracking in `UniCliServer`
- Remove `Diagnostic` command category (MeasureUpdateFrequency, ServerStatus)

## Test plan
- [x] `dotnet build` client passes
- [x] `unicli exec Compile --json` server compilation passes
- [x] `unicli status` shows PID, Server ID, Started, Uptime
- [x] `unicli status --json` returns all fields correctly