### PR TITLE
Add client/server version matching to install and check commands

### DIFF
--- a/src/UniCli.Client/ManifestEditor.cs
+++ b/src/UniCli.Client/ManifestEditor.cs
@@ -60,6 +60,32 @@ internal static class ManifestEditor
     }
 
     /// <summary>
+    /// Updates the source URL for the package in manifest.json.
+    /// Returns true if updated, false if the package is not installed.
+    /// </summary>
+    public static bool UpdatePackageSource(string manifestPath, string newSource)
+    {
+        if (!File.Exists(manifestPath))
+            throw new FileNotFoundException($"manifest.json not found: {manifestPath}");
+
+        var oldSource = FindPackageSource(manifestPath);
+        if (oldSource == null)
+            return false;
+
+        var text = File.ReadAllText(manifestPath);
+        var oldEntry = $"\"{PackageName}\": \"{oldSource}\"";
+        var newEntry = $"\"{PackageName}\": \"{newSource}\"";
+
+        var index = text.IndexOf(oldEntry, StringComparison.Ordinal);
+        if (index < 0)
+            return false;
+
+        var result = text.Remove(index, oldEntry.Length).Insert(index, newEntry);
+        File.WriteAllText(manifestPath, result);
+        return true;
+    }
+
+    /// <summary>
     /// Finds the position after the last entry value in the dependencies block
     /// (right after the closing quote of the last value, before any trailing whitespace/closing brace).
     /// </summary>

--- a/src/UniCli.Client/VersionInfo.cs
+++ b/src/UniCli.Client/VersionInfo.cs
@@ -1,0 +1,10 @@
+using System.Reflection;
+
+namespace UniCli.Client;
+
+internal static class VersionInfo
+{
+    public static string Version => typeof(VersionInfo).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion?.Split('+')[0] ?? "unknown";
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ProjectInfoHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ProjectInfoHandler.cs
@@ -29,6 +29,7 @@ namespace UniCli.Server.Editor.Handlers
             writer.WriteLine($"Playing:   {(response.isPlaying ? "Yes" : "No")}");
             writer.WriteLine($"PID:       {response.processId}");
             writer.WriteLine($"Server ID: {response.serverId}");
+            writer.WriteLine($"Version:   {response.serverVersion}");
             writer.WriteLine($"Started:   {response.startedAt}");
             writer.WriteLine($"Uptime:    {response.uptimeSeconds:F1}s");
 
@@ -37,6 +38,8 @@ namespace UniCli.Server.Editor.Handlers
 
         protected override ValueTask<ProjectInfoResponse> ExecuteAsync(Unit request)
         {
+            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(ProjectInfoHandler).Assembly);
+
             var response = new ProjectInfoResponse
             {
                 unityVersion = Application.unityVersion,
@@ -47,6 +50,7 @@ namespace UniCli.Server.Editor.Handlers
                 isPlaying = EditorApplication.isPlaying,
                 processId = Process.GetCurrentProcess().Id,
                 serverId = _context.ServerId,
+                serverVersion = packageInfo?.version ?? "unknown",
                 startedAt = _context.StartedAt.ToString("yyyy-MM-dd HH:mm:ss"),
                 uptimeSeconds = (DateTime.Now - _context.StartedAt).TotalSeconds
             };
@@ -66,6 +70,7 @@ namespace UniCli.Server.Editor.Handlers
         public bool isPlaying;
         public int processId;
         public string serverId;
+        public string serverVersion;
         public string startedAt;
         public double uptimeSeconds;
     }


### PR DESCRIPTION
## Summary
- `unicli install` now uses a versioned Git URL (`#v0.5.0`) by default, ensuring the server package version matches the client
- `unicli install --update` updates the package source URL in manifest.json for existing installations (preserving file formatting)
- `unicli check` queries the server for its version and displays both client and server versions, warning on mismatch
- `Project.Inspect` response now includes `serverVersion` via `PackageInfo.FindForAssembly`

## Test plan
- [x] `unicli check` displays matching client/server versions
- [x] `unicli check --json` includes `clientVersion`, `serverVersion`, `versionMatch` fields
- [x] `Project.Inspect --json` returns `serverVersion`
- [x] Unity compilation passes with 0 errors
- [x] EditMode tests pass (8/8)