### PR TITLE
Add Eval command for dynamic C# code execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,25 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec EditorUserBuildSettings.Inspe
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TypeCache.List '{"baseType":"UniCli.Server.Editor.Handlers.ICommandHandler"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TypeInspect '{"typeName":"UnityEditor.PlayerSettings"}' --json
 
+# Dynamic C# code execution (Eval)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval 'return Application.unityVersion;' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval 'return PlayerSettings.productName;' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval "$(cat <<'EOF'
+var go = GameObject.Find("Main Camera");
+return go.transform.position;
+EOF
+)" --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval "$(cat <<'EOF'
+var stats = new MyStats();
+stats.objectCount = GameObject.FindObjectsOfType<GameObject>().Length;
+return stats;
+EOF
+)" --declarations "$(cat <<'EOF'
+[System.Serializable]
+public class MyStats { public int objectCount; }
+EOF
+)" --json
+
 # Compile Unity project (also serves as a build verification for the server)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 ```

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CommandDispatcher.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CommandDispatcher.cs
@@ -109,11 +109,15 @@ namespace UniCli.Server.Editor
                     }
                 }
 
+                var jsonData = result is IRawJsonResponse rawJson
+                    ? rawJson.ToJson()
+                    : JsonUtility.ToJson(result);
+
                 return new CommandResponse
                 {
                     success = true,
                     message = $"Command '{request.command}' succeeded",
-                    data = JsonUtility.ToJson(result),
+                    data = jsonData,
                     format = "json"
                 };
             }
@@ -146,11 +150,15 @@ namespace UniCli.Server.Editor
                     }
                 }
 
+                var failJsonData = ex.ResponseData is IRawJsonResponse failRawJson
+                    ? failRawJson.ToJson()
+                    : JsonUtility.ToJson(ex.ResponseData);
+
                 return new CommandResponse
                 {
                     success = false,
                     message = $"Command failed: {ex.Message}",
-                    data = JsonUtility.ToJson(ex.ResponseData),
+                    data = failJsonData,
                     format = "json"
                 };
             }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -1,0 +1,280 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class EvalHandler : CommandHandler<EvalRequest, EvalResponse>
+    {
+        public override string CommandName => CommandNames.Eval;
+        public override string Description => "Compile and execute C# code dynamically in the Unity Editor context";
+
+        private static int _evalCounter;
+
+        protected override bool TryWriteFormatted(EvalResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"[{response.ResultType}]");
+                writer.WriteLine(response.ResultRaw);
+            }
+            else
+            {
+                writer.WriteLine(response.ResultRaw);
+            }
+
+            return true;
+        }
+
+        protected override async ValueTask<EvalResponse> ExecuteAsync(EvalRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.code))
+                throw new ArgumentException("code must not be empty");
+
+            var id = ++_evalCounter;
+            var className = $"UniCliEval_{id}";
+            var tempDir = Path.Combine("Temp", "UniCliEval");
+            var sourcePath = Path.Combine(tempDir, $"{className}.cs");
+            var dllPath = Path.Combine(tempDir, $"{className}.dll");
+
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var source = WrapUserCode(className, request.code, request.declarations);
+                await File.WriteAllTextAsync(sourcePath, source);
+
+                await CompileAsync(sourcePath, dllPath);
+
+                var assembly = System.Reflection.Assembly.Load(await File.ReadAllBytesAsync(dllPath));
+                var type = assembly.GetType(className);
+                var method = type.GetMethod("Execute", BindingFlags.Public | BindingFlags.Static);
+                object result;
+
+                try
+                {
+                    result = method.Invoke(null, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    var inner = ex.InnerException ?? ex;
+                    throw new CommandFailedException(
+                        $"Runtime error: {inner.Message}",
+                        EvalResponse.FromError(
+                            $"{inner.Message}\n{inner.StackTrace}",
+                            inner.GetType().FullName));
+                }
+
+                return EvalResponse.FromResult(result);
+            }
+            finally
+            {
+                if (File.Exists(sourcePath)) File.Delete(sourcePath);
+                if (File.Exists(dllPath)) File.Delete(dllPath);
+            }
+        }
+
+        private static string WrapUserCode(string className, string userCode, string declarations)
+        {
+            return
+$@"using System;
+using System.Linq;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+{declarations ?? ""}
+
+public static class {className}
+{{
+    public static object Execute()
+    {{
+        {userCode}
+        return null;
+    }}
+}}";
+        }
+
+        private static string[] GetAdditionalReferences()
+        {
+            var refs = new System.Collections.Generic.List<string>();
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (asm.IsDynamic) continue;
+                try
+                {
+                    var loc = asm.Location;
+                    if (!string.IsNullOrEmpty(loc))
+                        refs.Add(loc);
+                }
+                catch
+                {
+                    // some assemblies may throw on Location access
+                }
+            }
+            return refs.ToArray();
+        }
+
+        private static async Task CompileAsync(string sourcePath, string dllPath)
+        {
+            var tcs = new TaskCompletionSource<CompilerMessage[]>();
+
+            var builder = new AssemblyBuilder(dllPath, sourcePath)
+            {
+                referencesOptions = ReferencesOptions.UseEngineModules,
+                additionalReferences = GetAdditionalReferences()
+            };
+
+            builder.buildFinished += (path, messages) => { tcs.SetResult(messages); };
+
+            if (!builder.Build())
+                throw new CommandFailedException("AssemblyBuilder.Build() failed to start",
+                    EvalResponse.FromError("Failed to start compilation", "CompileError"));
+
+            var messages = await tcs.Task;
+
+            var errors = new System.Collections.Generic.List<string>();
+            foreach (var msg in messages)
+            {
+                if (msg.type == CompilerMessageType.Error)
+                    errors.Add(msg.message);
+            }
+
+            if (errors.Count > 0)
+            {
+                var errorText = string.Join("\n", errors);
+                throw new CommandFailedException(
+                    $"Compilation failed with {errors.Count} error(s)",
+                    EvalResponse.FromError(errorText, "CompileError"));
+            }
+        }
+    }
+
+    [Serializable]
+    public class EvalRequest
+    {
+        public string code;
+        public string declarations;
+    }
+
+    public class EvalResponse : IRawJsonResponse
+    {
+        public string ResultJson { get; private set; }
+        public string ResultType { get; private set; }
+        public string ResultRaw { get; private set; }
+
+        public static EvalResponse FromResult(object result)
+        {
+            if (result == null)
+                return new EvalResponse { ResultJson = "null", ResultType = "null", ResultRaw = "null" };
+
+            var typeName = result.GetType().FullName;
+            var (json, raw) = SerializeToJson(result);
+            return new EvalResponse { ResultJson = json, ResultType = typeName, ResultRaw = raw };
+        }
+
+        public static EvalResponse FromError(string message, string errorType)
+        {
+            return new EvalResponse
+            {
+                ResultJson = EscapeJsonString(message),
+                ResultType = errorType,
+                ResultRaw = message
+            };
+        }
+
+        public string ToJson()
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"result\":");
+            sb.Append(ResultJson);
+            sb.Append(",\"resultType\":");
+            sb.Append(EscapeJsonString(ResultType));
+            sb.Append('}');
+            return sb.ToString();
+        }
+
+        private static (string json, string raw) SerializeToJson(object result)
+        {
+            if (result is string s)
+                return (EscapeJsonString(s), s);
+
+            if (result is bool b)
+            {
+                var val = b ? "true" : "false";
+                return (val, val);
+            }
+
+            if (result is int or long or short or byte or sbyte or uint or ulong or ushort)
+            {
+                var val = result.ToString();
+                return (val, val);
+            }
+
+            if (result is float f)
+            {
+                var val = f.ToString("G9");
+                return (val, val);
+            }
+
+            if (result is double d)
+            {
+                var val = d.ToString("G17");
+                return (val, val);
+            }
+
+            if (result is UnityEngine.Object unityObj)
+            {
+                var json = EditorJsonUtility.ToJson(unityObj, true);
+                return (json, json);
+            }
+
+            try
+            {
+                var json = JsonUtility.ToJson(result);
+                if (json != "{}")
+                    return (json, json);
+            }
+            catch
+            {
+                // fall through to ToString
+            }
+
+            var str = result.ToString();
+            return (EscapeJsonString(str), str);
+        }
+
+        private static string EscapeJsonString(string s)
+        {
+            if (s == null) return "null";
+
+            var sb = new StringBuilder(s.Length + 2);
+            sb.Append('"');
+            foreach (var c in s)
+            {
+                switch (c)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20)
+                            sb.AppendFormat("\\u{0:x4}", (int)c);
+                        else
+                            sb.Append(c);
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 502b87931082a4f29b26ce8acfe8be20
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ICommandHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/ICommandHandler.cs
@@ -18,6 +18,11 @@ namespace UniCli.Server.Editor.Handlers
         bool TryWriteFormatted(object response, bool success, IFormatWriter writer);
     }
 
+    public interface IRawJsonResponse
+    {
+        string ToJson();
+    }
+
     public abstract class CommandHandler<TRequest, TResponse> : ICommandHandler, IResponseFormatter
     {
         public abstract string CommandName { get; }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -3,6 +3,7 @@ namespace UniCli.Server.Editor
     public static class CommandNames
     {
         public const string Compile = "Compile";
+        public const string Eval = "Eval";
         public const string Search = "Search";
 
         public static class BuildPlayer


### PR DESCRIPTION
## Summary

- Add `unicli eval` subcommand that compiles and executes arbitrary C# code in the Unity Editor context using `AssemblyBuilder`
- Support `--declarations` flag for custom type declarations (classes, structs, enums) used in the eval code
- Add `IRawJsonResponse` interface so Eval results are returned as raw JSON values instead of string-escaped JSON
- Update documentation (README, SKILL.md, CLAUDE.md) with Eval usage examples using shell heredocs

## Test plan

- [x] `unicli eval 'return 1+1;' --json` returns `{"result":2,"resultType":"System.Int32"}`
- [x] `unicli eval 'return Application.unityVersion;' --json` returns the Unity version
- [x] `unicli eval` with heredoc multi-line code works correctly
- [x] `unicli eval` with `--declarations` for custom types serializes properly
- [x] Compile errors return structured error messages
- [x] Runtime errors return exception details
- [x] Void operations (no return) return `null`