### PR TITLE
Add NuGetForUnity optional module

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -163,6 +163,10 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `TypeCache.List` | List types derived from a base type |
 | `TypeInspect` | Inspect nested types of a given type |
 | `Eval` | Compile and execute C# code dynamically in the Unity Editor context |
+| `NuGet.List` | List all installed NuGet packages (requires NuGetForUnity) |
+| `NuGet.Install` | Install a NuGet package (requires NuGetForUnity) |
+| `NuGet.Uninstall` | Uninstall a NuGet package (requires NuGetForUnity) |
+| `NuGet.Restore` | Restore all NuGet packages (requires NuGetForUnity) |
 
 ### Settings Commands (auto-generated)
 
@@ -385,6 +389,23 @@ Options:
 - `--json` — JSON output
 - `--declarations '<code>'` — Additional type declarations (classes, structs, enums) included outside the Execute method
 - `--timeout <ms>` — Set command timeout
+
+**NuGet package management (requires NuGetForUnity):**
+
+```bash
+# List installed NuGet packages
+unicli exec NuGet.List --json
+
+# Install a NuGet package
+unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
+unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
+
+# Uninstall a NuGet package
+unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
+
+# Restore all NuGet packages
+unicli exec NuGet.Restore --json
+```
 
 ## Running Custom Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,13 @@ public class MyStats { public int objectCount; }
 EOF
 )" --json
 
+# NuGet package management (requires NuGetForUnity)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.List --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Restore --json
+
 # Compile Unity project (also serves as a build verification for the server)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 ```

--- a/README.md
+++ b/README.md
@@ -318,6 +318,23 @@ EOF
 )" --json
 ```
 
+**NuGet package management (requires [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)):**
+
+```bash
+# List installed NuGet packages
+unicli exec NuGet.List --json
+
+# Install a NuGet package
+unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
+unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
+
+# Uninstall a NuGet package
+unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
+
+# Restore all NuGet packages
+unicli exec NuGet.Restore --json
+```
+
 
 ## Available Commands
 
@@ -398,6 +415,10 @@ The following commands are built in. You can also run `unicli commands` to see t
 | Utility            | `TypeCache.List`                     | List types derived from a base type |
 | Utility            | `TypeInspect`                        | Inspect nested types of a given type |
 | Eval               | `Eval`                               | Compile and execute C# code dynamically |
+| NuGet (optional)   | `NuGet.List`                         | List all installed NuGet packages  |
+| NuGet (optional)   | `NuGet.Install`                      | Install a NuGet package            |
+| NuGet (optional)   | `NuGet.Uninstall`                    | Uninstall a NuGet package          |
+| NuGet (optional)   | `NuGet.Restore`                      | Restore all NuGet packages         |
 
 Use `unicli exec <command> --help` to see parameters for any command.
 

--- a/src/UniCli.Unity/Assets/NuGet.config
+++ b/src/UniCli.Unity/Assets/NuGet.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" enableCredentialProvider="false" />
+  </packageSources>
+  <disabledPackageSources />
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+  <config>
+    <add key="packageInstallLocation" value="CustomWithinAssets" />
+    <add key="repositoryPath" value="./Packages" />
+    <add key="PackagesConfigDirectoryPath" value="." />
+    <add key="slimRestore" value="true" />
+    <add key="PreferNetStandardOverNetFramework" value="true" />
+  </config>
+</configuration>

--- a/src/UniCli.Unity/Assets/NuGet.config.meta
+++ b/src/UniCli.Unity/Assets/NuGet.config.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 555b8925e70934b5a8878dcd7179d416
+labels:
+- NuGetForUnity
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Assets/Packages.meta
+++ b/src/UniCli.Unity/Assets/Packages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f1fc080110c94f8daac4354f97d1f63
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Assets/packages.config
+++ b/src/UniCli.Unity/Assets/packages.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages />

--- a/src/UniCli.Unity/Assets/packages.config.meta
+++ b/src/UniCli.Unity/Assets/packages.config.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 8b26764588dbe4d269d77ea786acd5e5
+labels:
+- NuGetForUnity
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30834cf610f8c4985a7988bc9e6e1dc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetInstallHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetInstallHandler.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NugetForUnity;
+using NugetForUnity.Models;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    public sealed class NuGetInstallHandler : CommandHandler<NuGetInstallRequest, NuGetInstallResponse>
+    {
+        public override string CommandName => "NuGet.Install";
+        public override string Description => "Install a NuGet package by id and optional version";
+
+        protected override bool TryWriteFormatted(NuGetInstallResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Installed {response.id}@{response.version}"
+                : "Failed to install package");
+            return true;
+        }
+
+        protected override ValueTask<NuGetInstallResponse> ExecuteAsync(NuGetInstallRequest request)
+        {
+            if (string.IsNullOrEmpty(request.id))
+                throw new ArgumentException("id is required");
+
+            var existing = InstalledPackagesManager.InstalledPackages
+                .FirstOrDefault(p => string.Equals(p.Id, request.id, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null && string.IsNullOrEmpty(request.version))
+                throw new CommandFailedException(
+                    $"Package {request.id}@{existing.Version} is already installed",
+                    new NuGetInstallResponse { id = existing.Id, version = existing.Version });
+
+            var identifier = string.IsNullOrEmpty(request.version)
+                ? new NugetPackageIdentifier(request.id, string.Empty)
+                : new NugetPackageIdentifier(request.id, request.version);
+
+            var success = NugetPackageInstaller.InstallIdentifier(identifier);
+
+            if (!success)
+                throw new CommandFailedException(
+                    $"Failed to install package {request.id}",
+                    new NuGetInstallResponse { id = request.id, version = request.version ?? "" });
+
+            var installed = InstalledPackagesManager.InstalledPackages
+                .FirstOrDefault(p => string.Equals(p.Id, request.id, StringComparison.OrdinalIgnoreCase));
+
+            return new ValueTask<NuGetInstallResponse>(new NuGetInstallResponse
+            {
+                id = installed?.Id ?? request.id,
+                version = installed?.Version ?? request.version ?? "",
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetInstallRequest
+    {
+        public string id;
+        public string version;
+    }
+
+    [Serializable]
+    public class NuGetInstallResponse
+    {
+        public string id;
+        public string version;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetInstallHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetInstallHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51e88dfefbe51483f9e608e87d49301f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListHandler.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NugetForUnity;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    public sealed class NuGetListHandler : CommandHandler<Unit, NuGetListResponse>
+    {
+        public override string CommandName => "NuGet.List";
+        public override string Description => "List all installed NuGet packages";
+
+        protected override bool TryWriteFormatted(NuGetListResponse response, bool success, IFormatWriter writer)
+        {
+            var idWidth = "Id".Length;
+            var versionWidth = "Version".Length;
+
+            foreach (var pkg in response.packages)
+            {
+                idWidth = Math.Max(idWidth, pkg.id.Length);
+                versionWidth = Math.Max(versionWidth, pkg.version.Length);
+            }
+
+            writer.WriteLine($"{"Id".PadRight(idWidth)}  {"Version".PadRight(versionWidth)}");
+
+            foreach (var pkg in response.packages)
+            {
+                writer.WriteLine($"{pkg.id.PadRight(idWidth)}  {pkg.version.PadRight(versionWidth)}");
+            }
+
+            writer.WriteLine($"{response.totalCount} package(s)");
+
+            return true;
+        }
+
+        protected override ValueTask<NuGetListResponse> ExecuteAsync(Unit request)
+        {
+            var packages = InstalledPackagesManager.InstalledPackages
+                .Select(p => new NuGetPackageEntry
+                {
+                    id = p.Id,
+                    version = p.Version,
+                })
+                .OrderBy(p => p.id)
+                .ToArray();
+
+            return new ValueTask<NuGetListResponse>(new NuGetListResponse
+            {
+                packages = packages,
+                totalCount = packages.Length,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetListResponse
+    {
+        public NuGetPackageEntry[] packages;
+        public int totalCount;
+    }
+
+    [Serializable]
+    public class NuGetPackageEntry
+    {
+        public string id;
+        public string version;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8188a30b66b094c698aafacc28329776
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRestoreHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRestoreHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NugetForUnity;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    public sealed class NuGetRestoreHandler : CommandHandler<Unit, NuGetRestoreResponse>
+    {
+        public override string CommandName => "NuGet.Restore";
+        public override string Description => "Restore all NuGet packages from packages.config";
+
+        protected override bool TryWriteFormatted(NuGetRestoreResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Restored {response.packageCount} package(s)"
+                : "Failed to restore packages");
+            return true;
+        }
+
+        protected override ValueTask<NuGetRestoreResponse> ExecuteAsync(Unit request)
+        {
+            PackageRestorer.Restore(false);
+
+            var packageCount = InstalledPackagesManager.InstalledPackages.Count();
+
+            return new ValueTask<NuGetRestoreResponse>(new NuGetRestoreResponse
+            {
+                packageCount = packageCount,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetRestoreResponse
+    {
+        public int packageCount;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRestoreHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRestoreHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b8f76e8bb0824bfb85c4e2d4b3cf06b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetUninstallHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetUninstallHandler.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NugetForUnity;
+using NugetForUnity.Models;
+using NugetForUnity.PluginAPI;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    public sealed class NuGetUninstallHandler : CommandHandler<NuGetUninstallRequest, NuGetUninstallResponse>
+    {
+        public override string CommandName => "NuGet.Uninstall";
+        public override string Description => "Uninstall a NuGet package by id";
+
+        protected override bool TryWriteFormatted(NuGetUninstallResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Uninstalled {response.id}"
+                : "Failed to uninstall package");
+            return true;
+        }
+
+        protected override ValueTask<NuGetUninstallResponse> ExecuteAsync(NuGetUninstallRequest request)
+        {
+            if (string.IsNullOrEmpty(request.id))
+                throw new ArgumentException("id is required");
+
+            var installed = InstalledPackagesManager.InstalledPackages
+                .FirstOrDefault(p => string.Equals(p.Id, request.id, StringComparison.OrdinalIgnoreCase));
+
+            if (installed == null)
+                throw new CommandFailedException(
+                    $"Package {request.id} is not installed",
+                    new NuGetUninstallResponse { id = request.id });
+
+            NugetPackageUninstaller.Uninstall(
+                new NugetPackageIdentifier(installed.Id, installed.Version),
+                PackageUninstallReason.IndividualUninstall);
+
+            return new ValueTask<NuGetUninstallResponse>(new NuGetUninstallResponse
+            {
+                id = installed.Id,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetUninstallRequest
+    {
+        public string id;
+    }
+
+    [Serializable]
+    public class NuGetUninstallResponse
+    {
+        public string id;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetUninstallHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetUninstallHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e38a748df33334d02ad27999573a599d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/UniCli.Server.Editor.NuGetForUnity.asmdef
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/UniCli.Server.Editor.NuGetForUnity.asmdef
@@ -1,0 +1,29 @@
+{
+    "name": "UniCli.Server.Editor.NuGetForUnity",
+    "rootNamespace": "UniCli.Server.Editor.Handlers.NuGetForUnity",
+    "references": [
+        "UniCli.Server.Editor",
+        "NuGetForUnity"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "NuGetForUnity.PluginAPI.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "NUGET_FOR_UNITY"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.github-glitchenzo.nugetforunity",
+            "expression": "",
+            "define": "NUGET_FOR_UNITY"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/UniCli.Server.Editor.NuGetForUnity.asmdef.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/UniCli.Server.Editor.NuGetForUnity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81633941a6f724dc3b5a80a5b35462c9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/manifest.json
+++ b/src/UniCli.Unity/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.unity.collab-proxy": "2.11.3",
     "com.unity.feature.development": "1.0.1",
     "com.unity.textmeshpro": "3.0.7",

--- a/src/UniCli.Unity/Packages/packages-lock.json
+++ b/src/UniCli.Unity/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.github-glitchenzo.nugetforunity": {
+      "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "c2af83c9d4f8cdaada9d4a0e94de2f195d8e1d01"
+    },
     "com.unity.collab-proxy": {
       "version": "2.11.3",
       "depth": 0,


### PR DESCRIPTION
## Summary

- Add optional NuGetForUnity module with `NuGet.List`, `NuGet.Install`, `NuGet.Uninstall`, and `NuGet.Restore` commands
- Module is self-contained in a separate asmdef (`UniCli.Server.Editor.NuGetForUnity`) that only compiles when NuGetForUnity is installed, using `versionDefines` + `defineConstraints`
- No changes to existing files in the server package — handlers are auto-discovered via TypeCache

## Test plan

- [x] Verified compilation succeeds without NuGetForUnity (defineConstraints prevents compilation)
- [x] Verified compilation succeeds with NuGetForUnity installed (0 errors, 0 warnings)
- [x] Verified all 4 commands appear in `unicli commands` output
- [x] Tested `NuGet.List` — returns installed packages
- [x] Tested `NuGet.Install` — installs package by id/version
- [x] Tested `NuGet.Uninstall` — removes installed package
- [x] Tested `NuGet.Restore` — restores from packages.config
- [x] Existing EditMode tests pass (8/8)