### PR TITLE
Suppress CS0162/CS1998 warnings in eval generated code

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -108,7 +108,9 @@ namespace UniCli.Server.Editor.Handlers
         private static string WrapUserCode(string className, string userCode, string declarations)
         {
             return
-$@"using System;
+$@"#pragma warning disable CS0162 // Unreachable code detected
+#pragma warning disable CS1998 // Async method lacks await
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- Add `#pragma warning disable CS0162, CS1998` to eval-generated code to prevent compilation failures in projects with `TreatWarningsAsErrors`
- **CS0162** (Unreachable code): triggered by the fallback `return null;` after user code that already has a `return` statement
- **CS1998** (Async method lacks await): triggered when user code doesn't use `await` (sync-only eval)

## Test plan
- [x] `return EditorApplication.isPlaying;` — previously failed with CS0162, now succeeds
- [x] `return Application.unityVersion;` — sync without await (CS1998 suppressed)
- [x] `await Task.Delay(100); return 42;` — async still works
- [x] Unity compilation passes