### PR TITLE
Release v0.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "displayName": "UniCli Server",
   "description": "Unity Editor拡張機能 - CLIからUnityを操作するためのサーバー",
   "unity": "2022.3",


### PR DESCRIPTION
## Changelog

### Bug Fixes
- **Eval: suppress CS0162/CS1998 in generated code**: Projects with `TreatWarningsAsErrors` no longer fail eval compilation due to unreachable code (CS0162) or async-without-await (CS1998) warnings in the generated Execute() method (#38)

## Version Bump
- `src/UniCli.Client/UniCli.Client.csproj`: 0.7.1 → 0.7.2
- `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json`: 0.7.1 → 0.7.2
- `.claude-plugin/marketplace.json`: 0.7.1 → 0.7.2