### PR TITLE
Add PlayMode.Status command

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PlayMode/PlayModeHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/PlayMode/PlayModeHandler.cs
@@ -40,4 +40,38 @@ namespace UniCli.Server.Editor.Handlers
             return new ValueTask<Unit>(Unit.Value);
         }
     }
+
+    public sealed class PlayModeStatusHandler : CommandHandler<Unit, PlayModeStatusResponse>
+    {
+        public override string CommandName => CommandNames.PlayMode.Status;
+        public override string Description => "Get the current play mode state";
+
+        protected override bool TryWriteFormatted(PlayModeStatusResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success) return false;
+
+            writer.WriteLine($"isPlaying: {response.isPlaying}");
+            writer.WriteLine($"isPaused: {response.isPaused}");
+            writer.WriteLine($"isCompiling: {response.isCompiling}");
+            return true;
+        }
+
+        protected override ValueTask<PlayModeStatusResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            return new ValueTask<PlayModeStatusResponse>(new PlayModeStatusResponse
+            {
+                isPlaying = EditorApplication.isPlaying,
+                isPaused = EditorApplication.isPaused,
+                isCompiling = EditorApplication.isCompiling,
+            });
+        }
+    }
+
+    [System.Serializable]
+    public class PlayModeStatusResponse
+    {
+        public bool isPlaying;
+        public bool isPaused;
+        public bool isCompiling;
+    }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -23,6 +23,7 @@ namespace UniCli.Server.Editor
             public const string Enter = "PlayMode.Enter";
             public const string Exit = "PlayMode.Exit";
             public const string Pause = "PlayMode.Pause";
+            public const string Status = "PlayMode.Status";
         }
 
         public static class Menu


### PR DESCRIPTION
## Summary
- Add `PlayMode.Status` command that returns the current play mode state (`isPlaying`, `isPaused`, `isCompiling`)
- Enables CLI consumers to check whether the Unity Editor is in play mode, paused, or compiling before issuing other commands

## Test plan
- [x] `PlayMode.Status` returns `isPlaying: false, isPaused: false` when in Editor mode
- [x] `PlayMode.Status` returns `isPlaying: true, isPaused: false` after `PlayMode.Enter`
- [x] `PlayMode.Status` returns `isPlaying: true, isPaused: true` after `PlayMode.Pause`
- [x] Unity compilation passes with zero errors
- [x] Command appears in `commands --json` output