### PR TITLE
Add Screenshot.Capture command with client cwd protocol support

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -176,6 +176,7 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `Profiler.TakeSnapshot` | Take a memory snapshot (.snap file) |
 | `Profiler.AnalyzeFrames` | Analyze recorded frames and return aggregate statistics |
 | `Profiler.FindSpikes` | Find frames exceeding frame time or GC allocation thresholds |
+| `Screenshot.Capture` | Capture a screenshot of the Game View and save as PNG (requires Play Mode) |
 
 ### Settings Commands (auto-generated)
 
@@ -451,6 +452,19 @@ unicli exec Profiler.AnalyzeFrames '{"startFrame":100,"endFrame":200,"topSampleC
 # Find spike frames (frame time or GC threshold)
 unicli exec Profiler.FindSpikes '{"frameTimeThresholdMs":16.6}' --json
 unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024,"limit":5}' --json
+```
+
+**Screenshot operations (requires Play Mode):**
+
+```bash
+# Capture the Game View with default settings
+unicli exec Screenshot.Capture --json
+
+# Capture with a specific output path
+unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
+
+# Capture with super-sampling (2x resolution)
+unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
 ```
 
 ## Running Custom Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,11 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameT
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameTimeThresholdMs":16.6,"gcThresholdBytes":1024,"limit":5}' --json
 
+# Screenshot operations (requires Play Mode)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
+
 # Compile Unity project (also serves as a build verification for the server)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 ```

--- a/src/UniCli.Client/CommandExecutor.cs
+++ b/src/UniCli.Client/CommandExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -32,7 +33,8 @@ internal static class CommandExecutor
         {
             command = command,
             data = data,
-            format = format
+            format = format,
+            cwd = Directory.GetCurrentDirectory()
         };
 
         string lastError = "";

--- a/src/UniCli.Client/Protocol/CommandRequest.cs
+++ b/src/UniCli.Client/Protocol/CommandRequest.cs
@@ -8,5 +8,6 @@ namespace UniCli.Protocol
         public string command;
         public string data;
         public string format; // "json" or "text"; empty/null treated as "json"
+        public string cwd; // client's working directory for resolving relative paths
     }
 }

--- a/src/UniCli.Protocol/CommandRequest.cs
+++ b/src/UniCli.Protocol/CommandRequest.cs
@@ -8,5 +8,6 @@ namespace UniCli.Protocol
         public string command;
         public string data;
         public string format; // "json" or "text"; empty/null treated as "json"
+        public string cwd; // client's working directory for resolving relative paths
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31d406ad25a774543919797fa2e6e258
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class ScreenshotCaptureHandler : CommandHandler<ScreenshotCaptureRequest, ScreenshotCaptureResponse>
+    {
+        public override string CommandName => CommandNames.Screenshot.Capture;
+        public override string Description => "Capture a screenshot of the Game View and save as PNG (requires Play Mode)";
+
+        protected override bool TryWriteFormatted(ScreenshotCaptureResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"Screenshot saved to: {response.path}");
+                writer.WriteLine($"  Resolution: {response.width}x{response.height}");
+                writer.WriteLine($"  Size: {FormatBytes(response.size)}");
+            }
+            else
+            {
+                writer.WriteLine("Failed to capture screenshot");
+            }
+            return true;
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024L) return $"{bytes} B";
+            if (bytes < 1024L * 1024) return $"{bytes / 1024.0:F1} KB";
+            if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+            return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
+        }
+
+        protected override ValueTask<ScreenshotCaptureResponse> ExecuteAsync(ScreenshotCaptureRequest request, CancellationToken cancellationToken)
+        {
+            if (!EditorApplication.isPlaying)
+                throw new InvalidOperationException("Screenshot.Capture requires Play Mode. Use PlayMode.Enter first.");
+
+            var superSize = request.superSize > 0 ? request.superSize : 1;
+
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Screenshots", $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png")
+                : request.path;
+            path = ResolvePath(path);
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            int capturedWidth;
+            int capturedHeight;
+
+            Texture2D tex = null;
+            try
+            {
+                tex = ScreenCapture.CaptureScreenshotAsTexture(superSize);
+                if (tex == null)
+                    throw new InvalidOperationException("Failed to capture screenshot. Ensure the Game View is visible and rendering.");
+
+                capturedWidth = tex.width;
+                capturedHeight = tex.height;
+
+                var pngBytes = tex.EncodeToPNG();
+                File.WriteAllBytes(path, pngBytes);
+            }
+            finally
+            {
+                if (tex != null)
+                    UnityEngine.Object.DestroyImmediate(tex);
+            }
+
+            var fullPath = Path.GetFullPath(path);
+
+            if (!File.Exists(fullPath))
+                throw new InvalidOperationException($"Failed to save screenshot to: {fullPath}");
+
+            var fileInfo = new FileInfo(fullPath);
+            return new ValueTask<ScreenshotCaptureResponse>(new ScreenshotCaptureResponse
+            {
+                path = fullPath,
+                width = capturedWidth,
+                height = capturedHeight,
+                size = fileInfo.Length
+            });
+        }
+    }
+
+    [Serializable]
+    public class ScreenshotCaptureRequest
+    {
+        public string path;
+        public int superSize;
+    }
+
+    [Serializable]
+    public class ScreenshotCaptureResponse
+    {
+        public string path;
+        public int width;
+        public int height;
+        public long size;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c78852afab937412ab233e7d0fb10f8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -157,6 +157,11 @@ namespace UniCli.Server.Editor
             public const string FindSpikes = "Profiler.FindSpikes";
         }
 
+        public static class Screenshot
+        {
+            public const string Capture = "Screenshot.Capture";
+        }
+
         public static class Selection
         {
             public const string Get = "Selection.Get";

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandRequest.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandRequest.cs
@@ -8,5 +8,6 @@ namespace UniCli.Protocol
         public string command;
         public string data;
         public string format; // "json" or "text"; empty/null treated as "json"
+        public string cwd; // client's working directory for resolving relative paths
     }
 }


### PR DESCRIPTION
## Summary
- Add `Screenshot.Capture` command that captures the Game View using `ScreenCapture.CaptureScreenshotAsTexture` (requires Play Mode, supports `superSize` for super-sampling)
- Add `cwd` field to `CommandRequest` protocol so the server can resolve relative file paths against the client's working directory instead of the Unity project root
- Add `ResolvePath` helper to `CommandHandler` base class, reusable by any handler that writes files

## Test plan
- [x] `dotnet build src/UniCli.Protocol` succeeds
- [x] `dotnet publish src/UniCli.Client -o .build` succeeds
- [x] `unicli exec Compile` passes with no errors
- [x] `unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}'` saves the file relative to the CLI's working directory (not the Unity project root)
- [x] `unicli exec TestRunner.RunEditMode` passes (8/8)