### PR TITLE
Add Unity Recorder commands for video capture

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -176,6 +176,9 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `Profiler.TakeSnapshot` | Take a memory snapshot (.snap file) |
 | `Profiler.AnalyzeFrames` | Analyze recorded frames and return aggregate statistics |
 | `Profiler.FindSpikes` | Find frames exceeding frame time or GC allocation thresholds |
+| `Recorder.StartRecording` | Start recording Game View as video (requires Play Mode and com.unity.recorder) |
+| `Recorder.StopRecording` | Stop the current video recording |
+| `Recorder.Status` | Get the current recording status |
 | `Screenshot.Capture` | Capture a screenshot of the Game View and save as PNG (requires Play Mode) |
 
 ### Settings Commands (auto-generated)
@@ -465,6 +468,22 @@ unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
 
 # Capture with super-sampling (2x resolution)
 unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
+```
+
+**Video recording (requires Play Mode and com.unity.recorder):**
+
+```bash
+# Start recording with default settings (MP4, 30fps)
+unicli exec Recorder.StartRecording --json
+
+# Start with custom settings
+unicli exec Recorder.StartRecording '{"path":"Recordings/demo.mp4","format":"MP4","frameRate":60,"width":1920,"height":1080}' --json
+
+# Check recording status
+unicli exec Recorder.Status --json
+
+# Stop recording and save file
+unicli exec Recorder.StopRecording --json
 ```
 
 ## Running Custom Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,14 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameT
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameTimeThresholdMs":16.6,"gcThresholdBytes":1024,"limit":5}' --json
 
+# Recorder operations (requires Play Mode and com.unity.recorder package)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"path":"Recordings/test.mp4"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"format":"WebM","quality":"High","frameRate":60}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"width":1920,"height":1080}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.Status --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StopRecording --json
+
 # Screenshot operations (requires Play Mode)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4700b577962d84a09b38811d2a9f6801
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStartRecordingHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStartRecordingHandler.cs
@@ -1,0 +1,157 @@
+#if UNICLI_RECORDER
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEditor.Recorder;
+using UnityEditor.Recorder.Encoder;
+using UnityEditor.Recorder.Input;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class RecorderStartRecordingHandler : CommandHandler<RecorderStartRecordingRequest, RecorderStartRecordingResponse>
+    {
+        public override string CommandName => CommandNames.Recorder.StartRecording;
+        public override string Description => "Start recording the Game View as a video (requires Play Mode)";
+
+        protected override bool TryWriteFormatted(RecorderStartRecordingResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"Recording started: {response.path}");
+                writer.WriteLine($"  Format: {response.format}");
+                writer.WriteLine($"  Resolution: {response.width}x{response.height}");
+                writer.WriteLine($"  Frame Rate: {response.frameRate} fps");
+            }
+            else
+            {
+                writer.WriteLine("Failed to start recording");
+            }
+            return true;
+        }
+
+        protected override ValueTask<RecorderStartRecordingResponse> ExecuteAsync(RecorderStartRecordingRequest request, CancellationToken cancellationToken)
+        {
+            if (!EditorApplication.isPlaying)
+                throw new InvalidOperationException("Recorder.StartRecording requires Play Mode. Use PlayMode.Enter first.");
+
+            if (RecorderState.Controller != null && RecorderState.Controller.IsRecording())
+                throw new InvalidOperationException("Recording is already in progress. Use Recorder.StopRecording first.");
+
+            var format = string.IsNullOrEmpty(request.format) ? "MP4" : request.format.ToUpperInvariant();
+            var frameRate = request.frameRate > 0 ? request.frameRate : 30f;
+            var quality = string.IsNullOrEmpty(request.quality) ? "High" : request.quality;
+
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Recordings", $"recording_{DateTime.Now:yyyyMMdd_HHmmss}")
+                : request.path;
+            // Strip extension since Recorder appends it automatically
+            if (path.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".webm", StringComparison.OrdinalIgnoreCase))
+                path = path.Substring(0, path.LastIndexOf('.'));
+            path = ResolvePath(path);
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            var controllerSettings = ScriptableObject.CreateInstance<RecorderControllerSettings>();
+            controllerSettings.SetRecordModeToManual();
+            controllerSettings.FrameRate = frameRate;
+
+            var movieSettings = ScriptableObject.CreateInstance<MovieRecorderSettings>();
+            movieSettings.name = "UniCli Movie Recorder";
+            movieSettings.Enabled = true;
+            movieSettings.OutputFile = path;
+
+            if (format == "WEBM")
+            {
+                movieSettings.EncoderSettings = new CoreEncoderSettings
+                {
+                    Codec = CoreEncoderSettings.OutputCodec.WEBM,
+                    EncodingQuality = ParseQuality(quality),
+                };
+            }
+            else
+            {
+                movieSettings.EncoderSettings = new CoreEncoderSettings
+                {
+                    Codec = CoreEncoderSettings.OutputCodec.MP4,
+                    EncodingQuality = ParseQuality(quality),
+                };
+            }
+
+            movieSettings.CaptureAudio = request.captureAudio;
+
+            var imageInputSettings = movieSettings.ImageInputSettings as GameViewInputSettings;
+            if (imageInputSettings != null && request.width > 0 && request.height > 0)
+            {
+                imageInputSettings.OutputWidth = request.width;
+                imageInputSettings.OutputHeight = request.height;
+            }
+
+            controllerSettings.AddRecorderSettings(movieSettings);
+
+            var controller = new RecorderController(controllerSettings);
+            controller.PrepareRecording();
+            controller.StartRecording();
+
+            if (!controller.IsRecording())
+            {
+                UnityEngine.Object.DestroyImmediate(movieSettings);
+                UnityEngine.Object.DestroyImmediate(controllerSettings);
+                throw new InvalidOperationException("Failed to start recording. Ensure the Game View is visible.");
+            }
+
+            var actualWidth = request.width > 0 ? request.width : Screen.width;
+            var actualHeight = request.height > 0 ? request.height : Screen.height;
+
+            RecorderState.Controller = controller;
+            RecorderState.OutputPath = path + (format == "WEBM" ? ".webm" : ".mp4");
+
+            return new ValueTask<RecorderStartRecordingResponse>(new RecorderStartRecordingResponse
+            {
+                path = RecorderState.OutputPath,
+                format = format == "WEBM" ? "WebM" : "MP4",
+                width = actualWidth,
+                height = actualHeight,
+                frameRate = frameRate,
+            });
+        }
+
+        private static CoreEncoderSettings.VideoEncodingQuality ParseQuality(string quality)
+        {
+            switch (quality.ToLowerInvariant())
+            {
+                case "low": return CoreEncoderSettings.VideoEncodingQuality.Low;
+                case "medium": return CoreEncoderSettings.VideoEncodingQuality.Medium;
+                case "high": return CoreEncoderSettings.VideoEncodingQuality.High;
+                default: return CoreEncoderSettings.VideoEncodingQuality.High;
+            }
+        }
+    }
+
+    [Serializable]
+    public class RecorderStartRecordingRequest
+    {
+        public string path;
+        public string format;
+        public int width;
+        public int height;
+        public float frameRate;
+        public string quality;
+        public bool captureAudio;
+    }
+
+    [Serializable]
+    public class RecorderStartRecordingResponse
+    {
+        public string path;
+        public string format;
+        public int width;
+        public int height;
+        public float frameRate;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStartRecordingHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStartRecordingHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb4aa55fa55bb4ed4bb8ae07e73ea21f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderState.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderState.cs
@@ -1,0 +1,12 @@
+#if UNICLI_RECORDER
+using UnityEditor.Recorder;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal static class RecorderState
+    {
+        public static RecorderController Controller { get; set; }
+        public static string OutputPath { get; set; }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderState.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 595be2838920d4a219c0322b88b00bf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStatusHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStatusHandler.cs
@@ -1,0 +1,44 @@
+#if UNICLI_RECORDER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class RecorderStatusHandler : CommandHandler<Unit, RecorderStatusResponse>
+    {
+        public override string CommandName => CommandNames.Recorder.Status;
+        public override string Description => "Get the current recording status";
+
+        protected override bool TryWriteFormatted(RecorderStatusResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine(response.isRecording ? "Recording: active" : "Recording: inactive");
+            }
+            else
+            {
+                writer.WriteLine("Failed to get recording status");
+            }
+            return true;
+        }
+
+        protected override ValueTask<RecorderStatusResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            var isRecording = RecorderState.Controller != null && RecorderState.Controller.IsRecording();
+
+            return new ValueTask<RecorderStatusResponse>(new RecorderStatusResponse
+            {
+                isRecording = isRecording,
+            });
+        }
+    }
+
+    [Serializable]
+    public class RecorderStatusResponse
+    {
+        public bool isRecording;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStatusHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStatusHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f39f9ae72f09b49f7928ce6145c062d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStopRecordingHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStopRecordingHandler.cs
@@ -1,0 +1,81 @@
+#if UNICLI_RECORDER
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class RecorderStopRecordingHandler : CommandHandler<Unit, RecorderStopRecordingResponse>
+    {
+        public override string CommandName => CommandNames.Recorder.StopRecording;
+        public override string Description => "Stop the current video recording";
+
+        protected override bool TryWriteFormatted(RecorderStopRecordingResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"Recording saved to: {response.path}");
+                writer.WriteLine($"  Size: {FormatBytes(response.size)}");
+            }
+            else
+            {
+                writer.WriteLine("Failed to stop recording");
+            }
+            return true;
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024L) return $"{bytes} B";
+            if (bytes < 1024L * 1024) return $"{bytes / 1024.0:F1} KB";
+            if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+            return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
+        }
+
+        protected override ValueTask<RecorderStopRecordingResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            if (RecorderState.Controller == null || !RecorderState.Controller.IsRecording())
+                throw new InvalidOperationException("No recording is in progress. Use Recorder.StartRecording first.");
+
+            var controller = RecorderState.Controller;
+            var outputPath = RecorderState.OutputPath;
+
+            controller.StopRecording();
+
+            var controllerSettings = controller.Settings;
+            if (controllerSettings != null)
+            {
+                foreach (var recorder in controllerSettings.RecorderSettings)
+                {
+                    if (recorder != null)
+                        UnityEngine.Object.DestroyImmediate(recorder);
+                }
+                UnityEngine.Object.DestroyImmediate(controllerSettings);
+            }
+
+            RecorderState.Controller = null;
+            RecorderState.OutputPath = null;
+
+            long fileSize = 0;
+            if (File.Exists(outputPath))
+                fileSize = new FileInfo(outputPath).Length;
+
+            return new ValueTask<RecorderStopRecordingResponse>(new RecorderStopRecordingResponse
+            {
+                path = outputPath,
+                size = fileSize,
+            });
+        }
+    }
+
+    [Serializable]
+    public class RecorderStopRecordingResponse
+    {
+        public string path;
+        public long size;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStopRecordingHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Recorder/RecorderStopRecordingHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f561679d51e84d6695ce29ea1854ff6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Protocol/CommandNames.cs
@@ -157,6 +157,15 @@ namespace UniCli.Server.Editor
             public const string FindSpikes = "Profiler.FindSpikes";
         }
 
+#if UNICLI_RECORDER
+        public static class Recorder
+        {
+            public const string StartRecording = "Recorder.StartRecording";
+            public const string StopRecording = "Recorder.StopRecording";
+            public const string Status = "Recorder.Status";
+        }
+#endif
+
         public static class Screenshot
         {
             public const string Capture = "Screenshot.Capture";

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCli.Server.Editor.asmdef
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCli.Server.Editor.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "UniCli.Server.Editor",
     "rootNamespace": "UniCli.Server.Editor",
-    "references": [],
+    "references": [
+        "Unity.Recorder.Editor"
+    ],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,6 +14,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.recorder",
+            "expression": "",
+            "define": "UNICLI_RECORDER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/src/UniCli.Unity/Packages/manifest.json
+++ b/src/UniCli.Unity/Packages/manifest.json
@@ -2,8 +2,9 @@
   "dependencies": {
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.unity.collab-proxy": "2.11.3",
-    "com.unity.memoryprofiler": "1.1.1",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.memoryprofiler": "1.1.1",
+    "com.unity.recorder": "4.0.3",
     "com.unity.textmeshpro": "3.0.7",
     "com.unity.timeline": "1.7.7",
     "com.unity.ugui": "1.0.0",

--- a/src/UniCli.Unity/Packages/packages-lock.json
+++ b/src/UniCli.Unity/Packages/packages-lock.json
@@ -83,6 +83,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.recorder": {
+      "version": "4.0.3",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.timeline": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.settings-manager": {
       "version": "2.1.0",
       "depth": 2,


### PR DESCRIPTION
## Summary

- Add `Recorder.StartRecording`, `Recorder.StopRecording`, and `Recorder.Status` commands for recording the Game View as MP4/WebM video via the Unity Recorder package
- Conditionally compiled with `UNICLI_RECORDER` symbol using asmdef `versionDefines` — zero impact when `com.unity.recorder` is not installed
- Add `com.unity.recorder@4.0.3` as a dependency to the Unity project

## Details

### New Commands

| Command | Description |
|---|---|
| `Recorder.StartRecording` | Start recording the Game View (requires Play Mode). Supports `path`, `format` (MP4/WebM), `width`, `height`, `frameRate`, `quality`, `captureAudio` |
| `Recorder.StopRecording` | Stop the current recording and return file path and size |
| `Recorder.Status` | Check if a recording is currently in progress |

### Architecture

- `RecorderState` static class holds the `RecorderController` instance between Start/Stop calls
- Uses `CoreEncoderSettings` for MP4 (H.264) and WebM (VP8) codec configuration
- `GameViewInputSettings` for resolution control
- `RecorderControllerSettings.SetRecordModeToManual()` for explicit start/stop control

## Test plan

- [x] Unity compilation passes with 0 errors
- [x] EditMode tests pass (8/8)
- [x] All 3 Recorder commands appear in `unicli commands`
- [x] Verified full workflow: PlayMode.Enter → Recorder.StartRecording → Recorder.Status → Recorder.StopRecording → PlayMode.Exit