### PR TITLE
Add BuildMagic commands for build scheme management

### DIFF
--- a/samples/UniCli.Samples.Unity2022LTS/Packages/manifest.json
+++ b/samples/UniCli.Samples.Unity2022LTS/Packages/manifest.json
@@ -37,6 +37,7 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0",
+    "jp.co.cyberagent.buildmagic": "https://github.com/CyberAgentGameEntertainment/BuildMagic.git?path=/Packages/jp.co.cyberagent.buildmagic",
     "com.yucchiy.unicli-server": "file:../../../src/UniCli.Unity/Packages/com.yucchiy.unicli-server"
   }
 }

--- a/samples/UniCli.Samples.Unity2022LTS/Packages/packages-lock.json
+++ b/samples/UniCli.Samples.Unity2022LTS/Packages/packages-lock.json
@@ -141,6 +141,13 @@
       "source": "local",
       "dependencies": {}
     },
+    "jp.co.cyberagent.buildmagic": {
+      "version": "https://github.com/CyberAgentGameEntertainment/BuildMagic.git?path=/Packages/jp.co.cyberagent.buildmagic",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "98b119d519dcca44c17d1868257a90b8c88d55cc"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,

--- a/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/BuildMagic/Dev.json
+++ b/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/BuildMagic/Dev.json
@@ -1,0 +1,27 @@
+{
+    "_name": "Dev",
+    "_postBuildConfigurations": [],
+    "_internalPrepareConfigurations": [],
+    "_preBuildConfigurations": [
+        {
+            "rid": 1000
+        }
+    ],
+    "_baseSchemeName": "",
+    "references": {
+        "version": 2,
+        "RefIds": [
+            {
+                "rid": 1000,
+                "type": {
+                    "class": "EditorUserBuildSettingsSetDevelopmentTaskConfiguration",
+                    "ns": "BuildMagicEditor.BuiltIn",
+                    "asm": "BuildMagic.Editor"
+                },
+                "data": {
+                    "_value": true
+                }
+            }
+        ]
+    }
+}

--- a/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/BuildMagic/Prd.json
+++ b/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/BuildMagic/Prd.json
@@ -1,0 +1,27 @@
+{
+    "_name": "Prd",
+    "_postBuildConfigurations": [],
+    "_internalPrepareConfigurations": [],
+    "_preBuildConfigurations": [
+        {
+            "rid": 1000
+        }
+    ],
+    "_baseSchemeName": "",
+    "references": {
+        "version": 2,
+        "RefIds": [
+            {
+                "rid": 1000,
+                "type": {
+                    "class": "EditorUserBuildSettingsSetDevelopmentTaskConfiguration",
+                    "ns": "BuildMagicEditor.BuiltIn",
+                    "asm": "BuildMagic.Editor"
+                },
+                "data": {
+                    "_value": false
+                }
+            }
+        ]
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 150c5fbd54097450ca3f376e5a58505f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildMagicEditor;
+
+namespace UniCli.Server.Editor.Handlers.BuildMagic
+{
+    public sealed class BuildMagicApplyHandler : CommandHandler<BuildMagicApplyRequest, BuildMagicApplyResponse>
+    {
+        public override string CommandName => "BuildMagic.Apply";
+        public override string Description => "Apply a BuildMagic build scheme (run PreBuild tasks to configure project settings)";
+
+        protected override bool TryWriteFormatted(BuildMagicApplyResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Applied scheme '{response.name}' ({response.appliedTaskCount} task(s))"
+                : $"Failed to apply scheme '{response.name}'");
+            return true;
+        }
+
+        protected override ValueTask<BuildMagicApplyResponse> ExecuteAsync(BuildMagicApplyRequest request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            var allSchemes = BuildSchemeLoader.LoadAll<BuildScheme>().ToList();
+            var scheme = allSchemes.FirstOrDefault(s => s.Name == request.name);
+
+            if (scheme == null)
+                throw new CommandFailedException(
+                    $"Build scheme '{request.name}' not found",
+                    new BuildMagicApplyResponse { name = request.name, appliedTaskCount = 0 });
+
+            var preBuildTasks = ResolvePreBuildTasks(scheme, allSchemes);
+            BuildMagicEditor.BuildPipeline.PreBuild(preBuildTasks);
+
+            return new ValueTask<BuildMagicApplyResponse>(new BuildMagicApplyResponse
+            {
+                name = scheme.Name,
+                appliedTaskCount = preBuildTasks.Count,
+            });
+        }
+
+        private static IReadOnlyList<IBuildTask<IPreBuildContext>> ResolvePreBuildTasks(
+            BuildScheme scheme,
+            List<BuildScheme> allSchemes)
+        {
+            var buildMagicEditorAssembly = typeof(BuildSchemeLoader).Assembly;
+
+            var schemeUtilityType = buildMagicEditorAssembly.GetType("BuildMagicEditor.BuildSchemeUtility");
+            if (schemeUtilityType == null)
+                throw new InvalidOperationException("BuildSchemeUtility type not found");
+
+            // BuildSchemeUtility.EnumerateComposedConfigurations<IPreBuildContext>(scheme, allSchemes)
+            var enumerateConfigsMethod = schemeUtilityType
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .FirstOrDefault(m =>
+                    m.Name == "EnumerateComposedConfigurations" &&
+                    m.IsGenericMethod &&
+                    m.GetParameters().Length == 2);
+            if (enumerateConfigsMethod == null)
+                throw new InvalidOperationException("EnumerateComposedConfigurations method not found");
+
+            var genericConfigsMethod = enumerateConfigsMethod.MakeGenericMethod(typeof(IPreBuildContext));
+            var configurations = genericConfigsMethod.Invoke(null, new object[] { scheme, allSchemes });
+
+            // BuildTaskBuilderUtility.CreateBuildTasks<IPreBuildContext>(configurations)
+            var taskBuilderType = buildMagicEditorAssembly.GetType("BuildMagicEditor.BuildTaskBuilderUtility");
+            if (taskBuilderType == null)
+                throw new InvalidOperationException("BuildTaskBuilderUtility type not found");
+
+            var createTasksMethod = taskBuilderType
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .FirstOrDefault(m =>
+                    m.Name == "CreateBuildTasks" &&
+                    m.IsGenericMethod);
+            if (createTasksMethod == null)
+                throw new InvalidOperationException("CreateBuildTasks method not found");
+
+            var genericCreateMethod = createTasksMethod.MakeGenericMethod(typeof(IPreBuildContext));
+            var tasks = genericCreateMethod.Invoke(null, new object[] { configurations });
+
+            return (IReadOnlyList<IBuildTask<IPreBuildContext>>)tasks;
+        }
+    }
+
+    [Serializable]
+    public class BuildMagicApplyRequest
+    {
+        public string name;
+    }
+
+    [Serializable]
+    public class BuildMagicApplyResponse
+    {
+        public string name;
+        public int appliedTaskCount;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c7c90407277047d18ce18dab3781cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildMagicEditor;
+
+namespace UniCli.Server.Editor.Handlers.BuildMagic
+{
+    public sealed class BuildMagicInspectHandler : CommandHandler<BuildMagicInspectRequest, BuildMagicInspectResponse>
+    {
+        public override string CommandName => "BuildMagic.Inspect";
+        public override string Description => "Inspect a BuildMagic build scheme's configurations";
+
+        protected override bool TryWriteFormatted(BuildMagicInspectResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine($"Scheme: {response.name}");
+            if (!string.IsNullOrEmpty(response.baseSchemeName))
+                writer.WriteLine($"Base: {response.baseSchemeName}");
+
+            if (response.preBuildConfigurations.Length > 0)
+            {
+                writer.WriteLine("");
+                writer.WriteLine("PreBuild Configurations:");
+                foreach (var config in response.preBuildConfigurations)
+                {
+                    writer.WriteLine($"  - {config.taskType}: {config.propertyName}");
+                }
+            }
+
+            if (response.postBuildConfigurations.Length > 0)
+            {
+                writer.WriteLine("");
+                writer.WriteLine("PostBuild Configurations:");
+                foreach (var config in response.postBuildConfigurations)
+                {
+                    writer.WriteLine($"  - {config.taskType}: {config.propertyName}");
+                }
+            }
+
+            return true;
+        }
+
+        protected override ValueTask<BuildMagicInspectResponse> ExecuteAsync(BuildMagicInspectRequest request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            var allSchemes = BuildSchemeLoader.LoadAll<BuildScheme>().ToList();
+            var scheme = allSchemes.FirstOrDefault(s => s.Name == request.name);
+
+            if (scheme == null)
+                throw new CommandFailedException(
+                    $"Build scheme '{request.name}' not found",
+                    new BuildMagicInspectResponse
+                    {
+                        name = request.name,
+                        baseSchemeName = "",
+                        preBuildConfigurations = Array.Empty<BuildMagicConfigurationEntry>(),
+                        postBuildConfigurations = Array.Empty<BuildMagicConfigurationEntry>(),
+                    });
+
+            var preBuildConfigs = scheme.PreBuildConfigurations
+                .Select(ExtractConfigInfo)
+                .ToArray();
+
+            var postBuildConfigs = scheme.PostBuildConfigurations
+                .Select(ExtractConfigInfo)
+                .ToArray();
+
+            return new ValueTask<BuildMagicInspectResponse>(new BuildMagicInspectResponse
+            {
+                name = scheme.Name,
+                baseSchemeName = scheme.BaseSchemeName ?? "",
+                preBuildConfigurations = preBuildConfigs,
+                postBuildConfigurations = postBuildConfigs,
+            });
+        }
+
+        private static BuildMagicConfigurationEntry ExtractConfigInfo(IBuildConfiguration config)
+        {
+            return new BuildMagicConfigurationEntry
+            {
+                taskType = config.TaskType?.Name ?? "",
+                propertyName = config.PropertyName ?? "",
+            };
+        }
+    }
+
+    [Serializable]
+    public class BuildMagicInspectRequest
+    {
+        public string name;
+    }
+
+    [Serializable]
+    public class BuildMagicInspectResponse
+    {
+        public string name;
+        public string baseSchemeName;
+        public BuildMagicConfigurationEntry[] preBuildConfigurations;
+        public BuildMagicConfigurationEntry[] postBuildConfigurations;
+    }
+
+    [Serializable]
+    public class BuildMagicConfigurationEntry
+    {
+        public string taskType;
+        public string propertyName;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3e90603fe4b546acb691c635ab0b4f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildMagicEditor;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers.BuildMagic
+{
+    public sealed class BuildMagicListHandler : CommandHandler<Unit, BuildMagicListResponse>
+    {
+        public override string CommandName => "BuildMagic.List";
+        public override string Description => "List all BuildMagic build schemes";
+
+        protected override bool TryWriteFormatted(BuildMagicListResponse response, bool success, IFormatWriter writer)
+        {
+            var nameWidth = "Name".Length;
+            var baseWidth = "Base".Length;
+
+            foreach (var scheme in response.schemes)
+            {
+                nameWidth = Math.Max(nameWidth, scheme.name.Length);
+                baseWidth = Math.Max(baseWidth, (scheme.baseSchemeName ?? "").Length);
+            }
+
+            writer.WriteLine($"{"Name".PadRight(nameWidth)}  {"Base".PadRight(baseWidth)}  {"PreBuild".PadRight(10)}  {"PostBuild".PadRight(10)}");
+
+            foreach (var scheme in response.schemes)
+            {
+                writer.WriteLine(
+                    $"{scheme.name.PadRight(nameWidth)}  " +
+                    $"{(scheme.baseSchemeName ?? "").PadRight(baseWidth)}  " +
+                    $"{scheme.preBuildConfigCount.ToString().PadRight(10)}  " +
+                    $"{scheme.postBuildConfigCount.ToString().PadRight(10)}");
+            }
+
+            writer.WriteLine($"{response.totalCount} scheme(s)");
+
+            return true;
+        }
+
+        protected override ValueTask<BuildMagicListResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            var schemes = BuildSchemeLoader.LoadAll<BuildScheme>()
+                .Select(s => new BuildMagicSchemeEntry
+                {
+                    name = s.Name,
+                    baseSchemeName = s.BaseSchemeName ?? "",
+                    preBuildConfigCount = s.PreBuildConfigurations.Count,
+                    postBuildConfigCount = s.PostBuildConfigurations.Count,
+                })
+                .OrderBy(s => s.name)
+                .ToArray();
+
+            return new ValueTask<BuildMagicListResponse>(new BuildMagicListResponse
+            {
+                schemes = schemes,
+                totalCount = schemes.Length,
+            });
+        }
+    }
+
+    [Serializable]
+    public class BuildMagicListResponse
+    {
+        public BuildMagicSchemeEntry[] schemes;
+        public int totalCount;
+    }
+
+    [Serializable]
+    public class BuildMagicSchemeEntry
+    {
+        public string name;
+        public string baseSchemeName;
+        public int preBuildConfigCount;
+        public int postBuildConfigCount;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4113fc4917b03406194d41e762df8425
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/UniCli.Server.Editor.BuildMagic.asmdef
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/UniCli.Server.Editor.BuildMagic.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "UniCli.Server.Editor.BuildMagic",
+    "rootNamespace": "UniCli.Server.Editor.Handlers.BuildMagic",
+    "references": [
+        "UniCli.Server.Editor",
+        "BuildMagic.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNICLI_BUILDMAGIC"
+    ],
+    "versionDefines": [
+        {
+            "name": "jp.co.cyberagent.buildmagic",
+            "expression": "",
+            "define": "UNICLI_BUILDMAGIC"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/UniCli.Server.Editor.BuildMagic.asmdef.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/UniCli.Server.Editor.BuildMagic.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 474b0ae7612644874a29024821578407
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `BuildMagic.List`, `BuildMagic.Inspect`, and `BuildMagic.Apply` commands for [CyberAgent's BuildMagic](https://github.com/CyberAgentGameEntertainment/BuildMagic) integration
- Uses the same optional package pattern as NuGetForUnity: separate asmdef with `defineConstraints` + `versionDefines`, so projects without BuildMagic compile without errors
- `BuildMagic.Apply` uses reflection to access internal `BuildSchemeUtility` and `BuildTaskBuilderUtility` APIs for resolving scheme inheritance and executing PreBuild tasks
- Install BuildMagic via UPM in the Unity 2022 LTS sample project for testing

### New Commands
| Command | Description |
|---|---|
| `BuildMagic.List` | List all build schemes with name, base scheme, and configuration counts |
| `BuildMagic.Inspect` | Show detailed configurations (PreBuild/PostBuild tasks) for a named scheme |
| `BuildMagic.Apply` | Apply a scheme by running its PreBuild tasks to configure project settings |

## Test plan
- [x] `BuildMagic.List` returns correct scheme data (tested with Dev/Prd schemes)
- [x] `BuildMagic.Inspect` shows PreBuild configurations for each scheme
- [x] `BuildMagic.Apply` switches `EditorUserBuildSettings.development` between Dev/Prd schemes
- [x] `BuildMagic.Inspect` returns proper error for non-existent scheme
- [x] Main project (without BuildMagic) compiles with 0 errors — `defineConstraints` correctly skips the assembly
- [x] Sample project (with BuildMagic) compiles with 0 errors and registers all 3 commands