### PR TITLE
Release v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor拡張機能 - CLIからUnityを操作するためのサーバー",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
- Bump version to 0.10.0

## Changelog (since v0.9.0)
- **BuildMagic commands**: `BuildMagic.List`, `BuildMagic.Inspect`, `BuildMagic.Apply` for build scheme management
- **BuildProfile commands**: `BuildProfile.List`, `BuildProfile.GetActive`, `BuildProfile.SetActive`, `BuildProfile.Inspect` (Unity 6+)
- **Recorder commands**: `Recorder.StartRecording`, `Recorder.StopRecording`, `Recorder.Status`
- **Screenshot.Capture** command with `superSize` support
- Client `cwd` support in protocol for resolving relative paths
- Sample Unity projects for multi-version testing (Unity 2022 LTS, Unity 6 LTS)
- Fix BuildProfile `CommandFailedException` calls