### PR TITLE
Add command naming guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,8 @@ When adding or modifying commands, update the following files to keep them in sy
 - `README.md` — Available Commands table and Examples section
 - `.claude-plugin/unicli/skills/unity-development/SKILL.md` — Built-in Commands table and Common Workflows section
 
+When creating new commands, follow the naming conventions in `doc/command-naming-guidelines.md`.
+
 ### Releasing a new version
 
 1. Create a `release/vX.Y.Z` branch from `main`

--- a/README.md
+++ b/README.md
@@ -586,6 +586,8 @@ Once the handler is placed anywhere in your Unity project, it becomes immediatel
 unicli exec MyApp.Greet --name "World"
 ```
 
+For naming conventions (when to use concept-based names like `Scene.*` vs API-direct names like `AssetDatabase.*`), see [`doc/command-naming-guidelines.md`](doc/command-naming-guidelines.md).
+
 For commands that require no input or produce no output, use `Unit` as the type parameter:
 
 ```csharp

--- a/doc/command-naming-guidelines.md
+++ b/doc/command-naming-guidelines.md
@@ -60,7 +60,7 @@ When a command uses a concept-based name that differs from the Unity API, includ
 
 ```csharp
 // Good: users can find this via `unicli commands | grep PrefabUtility`
-public override string Description => "Save a GameObject as a prefab asset (PrefabUtility.SaveAsPrefabAsset)";
+public override string Description => "Save a GameObject as a prefab asset via PrefabUtility";
 
 // Good: API name matches, no extra annotation needed
 public override string Description => "Search assets in the AssetDatabase";
@@ -96,5 +96,5 @@ When naming a new command, walk through these questions:
    - No -> Reconsider the name
 
 4. **Does the command name differ from the Unity API name?**
-   - Yes -> Include the API name in the `Description` (e.g., `"... (PrefabUtility.SaveAsPrefabAsset)"`)
+   - Yes -> Include the API name naturally in the `Description` (e.g., `"... via PrefabUtility"`)
    - No -> No extra annotation needed

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabApplyHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class PrefabApplyHandler : CommandHandler<PrefabApplyRequest, PrefabApplyResponse>
     {
         public override string CommandName => CommandNames.Prefab.Apply;
-        public override string Description => "Apply overrides of a prefab instance to the source prefab asset (PrefabUtility)";
+        public override string Description => "Apply overrides of a prefab instance to the source prefab asset via PrefabUtility";
 
         protected override bool TryWriteFormatted(PrefabApplyResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabGetStatusHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class PrefabGetStatusHandler : CommandHandler<PrefabGetStatusRequest, PrefabGetStatusResponse>
     {
         public override string CommandName => CommandNames.Prefab.GetStatus;
-        public override string Description => "Get prefab instance status for a GameObject (PrefabUtility)";
+        public override string Description => "Get prefab instance status for a GameObject via PrefabUtility";
 
         protected override bool TryWriteFormatted(PrefabGetStatusResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
@@ -9,7 +9,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class PrefabInstantiateHandler : CommandHandler<PrefabInstantiateRequest, PrefabInstantiateResponse>
     {
         public override string CommandName => CommandNames.Prefab.Instantiate;
-        public override string Description => "Instantiate a prefab asset into the scene (PrefabUtility)";
+        public override string Description => "Instantiate a prefab asset into the scene via PrefabUtility";
 
         protected override bool TryWriteFormatted(PrefabInstantiateResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabSaveHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class PrefabSaveHandler : CommandHandler<PrefabSaveRequest, PrefabSaveResponse>
     {
         public override string CommandName => CommandNames.Prefab.Save;
-        public override string Description => "Save a GameObject as a prefab asset (PrefabUtility)";
+        public override string Description => "Save a GameObject as a prefab asset via PrefabUtility";
 
         protected override bool TryWriteFormatted(PrefabSaveResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabUnpackHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class PrefabUnpackHandler : CommandHandler<PrefabUnpackRequest, PrefabUnpackResponse>
     {
         public override string CommandName => CommandNames.Prefab.Unpack;
-        public override string Description => "Unpack a prefab instance, disconnecting it from the source prefab (PrefabUtility)";
+        public override string Description => "Unpack a prefab instance via PrefabUtility, disconnecting it from the source prefab";
 
         protected override bool TryWriteFormatted(PrefabUnpackResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneCloseHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneCloseHandler : CommandHandler<SceneCloseRequest, SceneCloseResponse>
     {
         public override string CommandName => CommandNames.Scene.Close;
-        public override string Description => "Close a loaded scene (EditorSceneManager)";
+        public override string Description => "Close a loaded scene via EditorSceneManager";
 
         protected override bool TryWriteFormatted(SceneCloseResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneGetActiveHandler.cs
@@ -9,7 +9,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneGetActiveHandler : CommandHandler<Unit, SceneInfoResponse>
     {
         public override string CommandName => CommandNames.Scene.GetActive;
-        public override string Description => "Get the active scene (SceneManager)";
+        public override string Description => "Get the active scene via SceneManager";
 
         protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneListHandler.cs
@@ -9,7 +9,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneListHandler : CommandHandler<Unit, SceneListResponse>
     {
         public override string CommandName => CommandNames.Scene.List;
-        public override string Description => "List all loaded scenes (SceneManager)";
+        public override string Description => "List all loaded scenes via SceneManager";
 
         protected override bool TryWriteFormatted(SceneListResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneNewHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneNewHandler : CommandHandler<SceneNewRequest, SceneInfoResponse>
     {
         public override string CommandName => CommandNames.Scene.New;
-        public override string Description => "Create a new scene (EditorSceneManager)";
+        public override string Description => "Create a new scene via EditorSceneManager";
 
         protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneOpenHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneOpenHandler : CommandHandler<SceneOpenRequest, SceneInfoResponse>
     {
         public override string CommandName => CommandNames.Scene.Open;
-        public override string Description => "Open a scene by asset path (EditorSceneManager)";
+        public override string Description => "Open a scene by asset path via EditorSceneManager";
 
         protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSaveHandler.cs
@@ -10,7 +10,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneSaveHandler : CommandHandler<SceneSaveRequest, SceneSaveResponse>
     {
         public override string CommandName => CommandNames.Scene.Save;
-        public override string Description => "Save a scene or all open scenes (EditorSceneManager)";
+        public override string Description => "Save a scene or all open scenes via EditorSceneManager";
 
         protected override bool TryWriteFormatted(SceneSaveResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneSetActiveHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class SceneSetActiveHandler : CommandHandler<SceneSetActiveRequest, SceneInfoResponse>
     {
         public override string CommandName => CommandNames.Scene.SetActive;
-        public override string Description => "Set the active scene (SceneManager)";
+        public override string Description => "Set the active scene via SceneManager";
 
         protected override bool TryWriteFormatted(SceneInfoResponse response, bool success, IFormatWriter writer)
         {


### PR DESCRIPTION
## Summary

- Add `doc/command-naming-guidelines.md` documenting the naming conventions for command handlers
- Two naming patterns:
  - **Concept-based**: Use when Unity API name is verbose or implementation-specific (`Scene` instead of `EditorSceneManager`, `Prefab` instead of `PrefabUtility`)
  - **API-direct**: Use when Unity class name is already well-known and concise (`AssetDatabase`, `AnimatorController`, `PackageManager`)
- Includes decision checklist for naming new commands
- Reference added to CLAUDE.md project structure

## Test plan

- Documentation only, no code changes