### PR TITLE
Execute Remote commands locally in editor PlayMode

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteHelper.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteHelper.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEditor.Networking.PlayerConnection;
+
+namespace UniCli.Server.Editor.Handlers.Remote
+{
+    internal static class RemoteHelper
+    {
+        public static bool ShouldExecuteLocally(int requestedPlayerId)
+        {
+            if (requestedPlayerId > 0)
+                return false;
+
+            return EditorApplication.isPlaying;
+        }
+
+        public static int ResolvePlayerId(int requestedId)
+        {
+            if (requestedId > 0)
+                return requestedId;
+
+            var players = EditorConnection.instance.ConnectedPlayers;
+            if (players.Count == 0)
+                throw new System.InvalidOperationException("No runtime player connected. Connect a Development Build first.");
+
+            return players[0].playerId;
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteHelper.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4d1621789b984a0fa53438864d8b62b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteInvokeHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteInvokeHandler.cs
@@ -3,8 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using UniCli.Protocol;
 using UniCli.Remote;
-using UnityEditor;
-using UnityEditor.Networking.PlayerConnection;
 using UnityEngine;
 
 namespace UniCli.Server.Editor.Handlers.Remote
@@ -44,10 +42,10 @@ namespace UniCli.Server.Editor.Handlers.Remote
             if (string.IsNullOrEmpty(request.command))
                 throw new ArgumentException("'command' is required");
 
-            if (ShouldExecuteLocally(request.playerId))
+            if (RemoteHelper.ShouldExecuteLocally(request.playerId))
                 return ExecuteLocally(request);
 
-            var playerId = ResolvePlayerId(request.playerId);
+            var playerId = RemoteHelper.ResolvePlayerId(request.playerId);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -106,25 +104,6 @@ namespace UniCli.Server.Editor.Handlers.Remote
             };
         }
 
-        private static bool ShouldExecuteLocally(int requestedPlayerId)
-        {
-            if (requestedPlayerId > 0)
-                return false;
-
-            return EditorApplication.isPlaying;
-        }
-
-        private static int ResolvePlayerId(int requestedId)
-        {
-            if (requestedId > 0)
-                return requestedId;
-
-            var players = EditorConnection.instance.ConnectedPlayers;
-            if (players.Count == 0)
-                throw new InvalidOperationException("No runtime player connected. Connect a Development Build first.");
-
-            return players[0].playerId;
-        }
     }
 
     [Serializable]

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Remote/RemoteListHandler.cs
@@ -3,8 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using UniCli.Protocol;
 using UniCli.Remote;
-using UnityEditor;
-using UnityEditor.Networking.PlayerConnection;
 using UnityEngine;
 
 namespace UniCli.Server.Editor.Handlers.Remote
@@ -42,10 +40,10 @@ namespace UniCli.Server.Editor.Handlers.Remote
 
         protected override async ValueTask<RemoteListResponse> ExecuteAsync(RemoteListRequest request, CancellationToken cancellationToken)
         {
-            if (ShouldExecuteLocally(request.playerId))
+            if (RemoteHelper.ShouldExecuteLocally(request.playerId))
                 return ExecuteListLocally();
 
-            var playerId = ResolvePlayerId(request.playerId);
+            var playerId = RemoteHelper.ResolvePlayerId(request.playerId);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(10));
@@ -70,25 +68,6 @@ namespace UniCli.Server.Editor.Handlers.Remote
             };
         }
 
-        private static bool ShouldExecuteLocally(int requestedPlayerId)
-        {
-            if (requestedPlayerId > 0)
-                return false;
-
-            return EditorApplication.isPlaying;
-        }
-
-        private static int ResolvePlayerId(int requestedId)
-        {
-            if (requestedId > 0)
-                return requestedId;
-
-            var players = EditorConnection.instance.ConnectedPlayers;
-            if (players.Count == 0)
-                throw new InvalidOperationException("No runtime player connected. Connect a Development Build first.");
-
-            return players[0].playerId;
-        }
     }
 
     [Serializable]


### PR DESCRIPTION
## Summary
- When the editor is in PlayMode and no `playerId` is specified, `Remote.Invoke` and `Remote.List` now execute debug commands directly via `DebugCommandRegistry` instead of going through PlayerConnection
- If a specific `playerId` is provided, the commands still go through PlayerConnection as before
- This allows using `Remote.Invoke '{"command":"Debug.Stats"}'` etc. during editor PlayMode without needing a connected Development Build

## Behavior

| Condition | Behavior |
|---|---|
| PlayMode + no playerId | Execute locally via DebugCommandRegistry |
| PlayMode + playerId specified | Send via PlayerConnection (existing behavior) |
| Not in PlayMode | Send via PlayerConnection (existing behavior) |

## Test plan
- [x] Unity compilation: 0 errors
- [x] EditMode tests: 39/39 passed
- [x] Manual: enter PlayMode, run `Remote.List` → returns commands without connected player
- [x] Manual: enter PlayMode, run `Remote.Invoke '{"command":"Debug.Stats"}'` → returns stats