### PR TITLE
Fix Windows compatibility for cache path and CRLF handling

### DIFF
--- a/src/UniCli.Client/CompletionCache.cs
+++ b/src/UniCli.Client/CompletionCache.cs
@@ -10,10 +10,17 @@ internal static class CompletionCache
     public static string GetCacheDir(string projectRoot)
     {
         var hash = ProjectIdentifier.GetProjectHash(projectRoot);
-        var cacheDir = Path.Combine(
+
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "unicli", hash);
+        }
+
+        return Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".cache", "unicli", hash);
-        return cacheDir;
     }
 
     public static void Save(string projectRoot, CommandInfo[] commands)

--- a/src/UniCli.Client/ManifestEditor.cs
+++ b/src/UniCli.Client/ManifestEditor.cs
@@ -139,10 +139,13 @@ internal static class ManifestEditor
         while (lineStart > 0 && text[lineStart - 1] != '\n')
             lineStart--;
 
-        // Extract leading whitespace
+        // Extract leading whitespace (skip '\r' from CRLF but don't include it in indent)
         var indent = "";
-        for (var i = lineStart; i < text.Length && (text[i] == ' ' || text[i] == '\t'); i++)
-            indent += text[i];
+        for (var i = lineStart; i < text.Length && (text[i] == ' ' || text[i] == '\t' || text[i] == '\r'); i++)
+        {
+            if (text[i] != '\r')
+                indent += text[i];
+        }
 
         return indent.Length > 0 ? indent : "    ";
     }


### PR DESCRIPTION
## Summary
- Use `%LOCALAPPDATA%\unicli\{hash}` as cache directory on Windows instead of `~/.cache/unicli/{hash}` (macOS/Linux behavior unchanged)
- Skip `\r` in `ManifestEditor.DetectEntryIndent` so indent detection works correctly with CRLF line endings on Windows

## Test plan
- [x] `dotnet publish` build succeeded
- [x] `exec Compile` with 0 errors
- [x] `TestRunner.RunEditMode` passed 39/39 tests