### PR TITLE
Modularize BuildMagic and consolidate Type commands

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -164,8 +164,8 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `Scene.Close` | Close a loaded scene |
 | `Scene.Save` | Save a scene or all open scenes |
 | `Scene.New` | Create a new scene |
-| `TypeCache.List` | List types derived from a base type |
-| `TypeInspect` | Inspect nested types of a given type |
+| `Type.List` | List types derived from a base type |
+| `Type.Inspect` | Inspect nested types of a given type |
 | `Eval` | Compile and execute C# code dynamically in the Unity Editor context |
 | `NuGet.List` | List all installed NuGet packages (requires NuGetForUnity) |
 | `NuGet.Install` | Install a NuGet package (requires NuGetForUnity) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,9 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec EditorUserBuildSettings.Inspe
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval 'PlayerSettings.companyName = "MyCompany";' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval 'PlayerSettings.SetScriptingBackend(UnityEditor.Build.NamedBuildTarget.Android, ScriptingImplementation.IL2CPP);' --json
 
-# TypeCache and type inspection
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TypeCache.List '{"baseType":"UniCli.Server.Editor.Handlers.ICommandHandler"}' --json
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TypeInspect '{"typeName":"UnityEditor.PlayerSettings"}' --json
+# Type inspection
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Type.List '{"baseType":"UniCli.Server.Editor.Handlers.ICommandHandler"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Type.Inspect '{"typeName":"UnityEditor.PlayerSettings"}' --json
 
 # Dynamic C# code execution (Eval)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli eval 'return Application.unityVersion;' --json

--- a/README.md
+++ b/README.md
@@ -524,8 +524,8 @@ The following commands are built in. You can also run `unicli commands` to see t
 | Scene              | `Scene.Close`                        | Close a loaded scene               |
 | Scene              | `Scene.Save`                         | Save a scene or all open scenes    |
 | Scene              | `Scene.New`                          | Create a new scene                 |
-| Utility            | `TypeCache.List`                     | List types derived from a base type |
-| Utility            | `TypeInspect`                        | Inspect nested types of a given type |
+| Utility            | `Type.List`                          | List types derived from a base type |
+| Utility            | `Type.Inspect`                       | Inspect nested types of a given type |
 | Eval               | `Eval`                               | Compile and execute C# code dynamically |
 | NuGet (optional)   | `NuGet.List`                         | List all installed NuGet packages  |
 | NuGet (optional)   | `NuGet.Install`                      | Install a NuGet package            |

--- a/src/UniCli.Client/Commands/Commands.Commands.cs
+++ b/src/UniCli.Client/Commands/Commands.Commands.cs
@@ -66,7 +66,8 @@ public partial class Commands
         foreach (var cmd in commands)
         {
             var paddedName = cmd.name.PadRight(maxNameLen);
-            sb.AppendLine($"  {paddedName}  {cmd.description}");
+            var modulePart = $" [{(string.IsNullOrEmpty(cmd.module) ? "Core" : cmd.module)}]";
+            sb.AppendLine($"  {paddedName}  {cmd.description}{modulePart}");
 
             if (cmd.requestFields.Length > 0)
             {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicApplyHandler.cs
@@ -8,6 +8,7 @@ using BuildMagicEditor;
 
 namespace UniCli.Server.Editor.Handlers.BuildMagic
 {
+    [Module("BuildMagic")]
     public sealed class BuildMagicApplyHandler : CommandHandler<BuildMagicApplyRequest, BuildMagicApplyResponse>
     {
         public override string CommandName => "BuildMagic.Apply";

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicInspectHandler.cs
@@ -6,6 +6,7 @@ using BuildMagicEditor;
 
 namespace UniCli.Server.Editor.Handlers.BuildMagic
 {
+    [Module("BuildMagic")]
     public sealed class BuildMagicInspectHandler : CommandHandler<BuildMagicInspectRequest, BuildMagicInspectResponse>
     {
         public override string CommandName => "BuildMagic.Inspect";

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildMagic/BuildMagicListHandler.cs
@@ -7,6 +7,7 @@ using UniCli.Protocol;
 
 namespace UniCli.Server.Editor.Handlers.BuildMagic
 {
+    [Module("BuildMagic")]
     public sealed class BuildMagicListHandler : CommandHandler<Unit, BuildMagicListResponse>
     {
         public override string CommandName => "BuildMagic.List";

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 445d245108640451ab8cb612207920f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeCacheListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeCacheListHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
 {
     public sealed class TypeCacheListHandler : CommandHandler<TypeCacheListRequest, TypeCacheListResponse>
     {
-        public override string CommandName => "TypeCache.List";
+        public override string CommandName => "Type.List";
         public override string Description => "List types derived from a base type or matching a pattern";
 
         protected override ValueTask<TypeCacheListResponse> ExecuteAsync(TypeCacheListRequest request, CancellationToken cancellationToken)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeCacheListHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeCacheListHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3b5d7446dd89d49ca904feee33dcff79
+guid: 7d431f994ecd046b0b110a8c66f7cfcd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeInspectHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeInspectHandler.cs
@@ -8,7 +8,7 @@ namespace UniCli.Server.Editor.Handlers
 {
     public sealed class TypeInspectHandler : CommandHandler<TypeInspectRequest, TypeInspectResponse>
     {
-        public override string CommandName => "TypeInspect";
+        public override string CommandName => "Type.Inspect";
         public override string Description => "Inspect nested types of a given type";
 
         protected override ValueTask<TypeInspectResponse> ExecuteAsync(TypeInspectRequest request, CancellationToken cancellationToken)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeInspectHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Types/TypeInspectHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e4ba5e58adf8d48f59e03a965aefc1a4
+guid: 8ba6d359717174d8580b9f9e1aa49540
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/ModuleRegistry.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/ModuleRegistry.cs
@@ -19,6 +19,7 @@ namespace UniCli.Server.Editor
 
             new ModuleDefinition("Recorder", "Video recording operations (requires com.unity.recorder)"),
             new ModuleDefinition("NuGet", "NuGet package management (requires NuGetForUnity)"),
+            new ModuleDefinition("BuildMagic", "BuildMagic build scheme operations (requires jp.co.cyberagent.buildmagic)"),
         };
 
         /// <summary>


### PR DESCRIPTION
## Summary

- **BuildMagic modularization**: Added `[Module("BuildMagic")]` attribute to all three BuildMagic handlers (`List`, `Inspect`, `Apply`) and registered `BuildMagic` in `ModuleRegistry`, so it can be enabled/disabled like other optional modules
- **Type command consolidation**: Renamed `TypeInspect` → `Type.Inspect` and `TypeCache.List` → `Type.List` for consistent naming under the `Type.*` category, and moved handlers to `Editor/Handlers/Types/` directory
- **Module label in commands output**: The human-readable `commands` output now shows the module name for every command (e.g. `[Animation]`, `[Assets]`, `[Core]`)

## Test plan

- [x] Unity compilation passes (`exec Compile`)
- [x] `Module.List` shows BuildMagic module
- [x] `commands` shows `Type.Inspect` and `Type.List` (old names removed)
- [x] `commands` human-readable output shows module labels for all commands
- [x] EditMode tests pass (39/39)