### PR TITLE
Skip link.xml generation when UniCli.Remote is excluded from build

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Build/RemoteLinkerProcessor.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Build/RemoteLinkerProcessor.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.UnityLinker;
@@ -11,9 +13,27 @@ namespace UniCli.Server.Editor.Build
 
         public string GenerateAdditionalLinkXmlFile(BuildReport report, UnityLinkerBuildPipelineData data)
         {
+            if (!IsRemoteAssemblyIncluded(report))
+                return null;
+
             var path = Path.Combine(data.inputDirectory, "UniCli.Remote.link.xml");
             File.WriteAllText(path, "<linker>\n  <assembly fullname=\"UniCli.Remote\" preserve=\"all\" />\n</linker>\n");
             return path;
+        }
+
+        private static bool IsRemoteAssemblyIncluded(BuildReport report)
+        {
+            // UniCli.Remote asmdef defineConstraints:
+            //   "DEVELOPMENT_BUILD || UNITY_EDITOR"
+            //   "UNICLI_REMOTE || UNITY_EDITOR"
+            // In player builds UNITY_EDITOR is not defined,
+            // so both DEVELOPMENT_BUILD and UNICLI_REMOTE must be present.
+            if ((report.summary.options & BuildOptions.Development) == 0)
+                return false;
+
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(report.summary.platform);
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup);
+            return Array.IndexOf(defines.Split(';'), "UNICLI_REMOTE") >= 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

- `RemoteLinkerProcessor` unconditionally generated a `link.xml` preserving the `UniCli.Remote` assembly during every build, even when the assembly was not compiled
- The `UniCli.Remote` asmdef has `defineConstraints` requiring both `DEVELOPMENT_BUILD` and `UNICLI_REMOTE` for player builds — in Release builds or without `UNICLI_REMOTE`, the assembly is excluded
- Now `RemoteLinkerProcessor` checks `BuildOptions.Development` and the `UNICLI_REMOTE` scripting define before generating the linker entry, matching the asmdef constraints

## Test plan

- [x] Unity compilation: 0 errors
- [x] EditMode tests: 39/39 passed
- [x] Verify Release build no longer emits `UniCli.Remote.link.xml`
- [x] Verify Development Build with `UNICLI_REMOTE` still preserves the assembly