### PR TITLE
Add BuildTarget.GetActive and BuildTarget.Switch commands

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetGetActiveHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetGetActiveHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class BuildTargetGetActiveHandler : CommandHandler<Unit, BuildTargetGetActiveResponse>
+    {
+        public override string CommandName => "BuildTarget.GetActive";
+        public override string Description => "Get the active build target and build target group via EditorUserBuildSettings";
+
+        protected override bool TryWriteFormatted(BuildTargetGetActiveResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success)
+                return false;
+
+            writer.WriteLine($"Build Target: {response.buildTarget}");
+            writer.WriteLine($"Target Group: {response.buildTargetGroup}");
+
+            return true;
+        }
+
+        protected override ValueTask<BuildTargetGetActiveResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            var target = EditorUserBuildSettings.activeBuildTarget;
+            var group = BuildPipeline.GetBuildTargetGroup(target);
+
+            return new ValueTask<BuildTargetGetActiveResponse>(new BuildTargetGetActiveResponse
+            {
+                buildTarget = target.ToString(),
+                buildTargetGroup = group.ToString(),
+            });
+        }
+    }
+
+    [Serializable]
+    public class BuildTargetGetActiveResponse
+    {
+        public string buildTarget;
+        public string buildTargetGroup;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetGetActiveHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetGetActiveHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5177d29b49f2341fc9a7b941445def8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetSwitchHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetSwitchHandler.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class BuildTargetSwitchHandler : CommandHandler<BuildTargetSwitchRequest, BuildTargetSwitchResponse>
+    {
+        public override string CommandName => "BuildTarget.Switch";
+        public override string Description => "Switch the active build target via EditorUserBuildSettings.SwitchActiveBuildTarget";
+
+        protected override bool TryWriteFormatted(BuildTargetSwitchResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success)
+                return false;
+
+            writer.WriteLine($"Switched to {response.buildTarget} ({response.buildTargetGroup})");
+
+            return true;
+        }
+
+        protected override ValueTask<BuildTargetSwitchResponse> ExecuteAsync(BuildTargetSwitchRequest request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.target))
+                throw new ArgumentException("target is required (e.g. Android, iOS, StandaloneWindows64, StandaloneOSX, WebGL)");
+
+            if (!Enum.TryParse<BuildTarget>(request.target, true, out var target))
+                throw new ArgumentException($"Invalid build target: '{request.target}'. Use a valid BuildTarget name (e.g. Android, iOS, StandaloneWindows64, StandaloneOSX, WebGL).");
+
+            var group = BuildPipeline.GetBuildTargetGroup(target);
+
+            var switched = EditorUserBuildSettings.SwitchActiveBuildTarget(group, target);
+            if (!switched)
+                throw new CommandFailedException($"Failed to switch build target to {target}", new { target = target.ToString() });
+
+            return new ValueTask<BuildTargetSwitchResponse>(new BuildTargetSwitchResponse
+            {
+                buildTarget = target.ToString(),
+                buildTargetGroup = group.ToString(),
+            });
+        }
+    }
+
+    [Serializable]
+    public class BuildTargetSwitchRequest
+    {
+        public string target;
+    }
+
+    [Serializable]
+    public class BuildTargetSwitchResponse
+    {
+        public string buildTarget;
+        public string buildTargetGroup;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetSwitchHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/BuildTargetSwitchHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3c1d436ee57a408d9cd51c11e56b5e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- **`BuildTarget.GetActive`**: Returns the current active build target and build target group via `EditorUserBuildSettings.activeBuildTarget`
- **`BuildTarget.Switch`**: Switches the active build target via `EditorUserBuildSettings.SwitchActiveBuildTarget`, with validation for the target name

## Usage

```bash
unicli exec BuildTarget.GetActive
# Build Target: Android
# Target Group: Android

unicli exec BuildTarget.Switch '{"target":"iOS"}'
# Switched to iOS (iOS)
```

## Test plan

- [x] Unity compilation: 0 errors
- [x] EditMode tests: 39/39 passed
- [x] `BuildTarget.GetActive` returns correct target