### PR TITLE
Update README and SKILL.md with all available commands for v1

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -91,6 +91,8 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `BuildProfile.GetActive` | Get the active build profile (Unity 6+ only) |
 | `BuildProfile.SetActive` | Set the active build profile (Unity 6+ only) |
 | `BuildProfile.Inspect` | Inspect a build profile's details (Unity 6+ only) |
+| `BuildTarget.GetActive` | Get the active build target and target group |
+| `BuildTarget.Switch` | Switch the active build target |
 | `Compile` | Compile scripts and return results |
 | `Connection.List` | List available connection targets (players/devices) |
 | `Connection.Connect` | Connect to a target by ID, IP, or device ID |
@@ -100,6 +102,7 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `PlayMode.Enter` | Enter play mode |
 | `PlayMode.Exit` | Exit play mode |
 | `PlayMode.Pause` | Toggle pause |
+| `PlayMode.Status` | Get the current play mode state |
 | `Menu.List` | List menu items |
 | `Menu.Execute` | Execute a menu item by path |
 | `TestRunner.RunEditMode` | Run EditMode tests |
@@ -164,9 +167,19 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `Scene.Close` | Close a loaded scene |
 | `Scene.Save` | Save a scene or all open scenes |
 | `Scene.New` | Create a new scene |
+| `Selection.Get` | Get the current editor selection |
+| `Selection.SetAsset` | Select an asset by path |
+| `Selection.SetAssets` | Select multiple assets by paths |
+| `Selection.SetGameObject` | Select a GameObject by path |
+| `Selection.SetGameObjects` | Select multiple GameObjects by paths |
+| `Window.List` | List all available EditorWindow types |
+| `Window.Open` | Open an EditorWindow by type name |
+| `Window.Focus` | Focus an already-open EditorWindow |
+| `Window.Create` | Create a new EditorWindow instance |
 | `Type.List` | List types derived from a base type |
 | `Type.Inspect` | Inspect nested types of a given type |
 | `Eval` | Compile and execute C# code dynamically in the Unity Editor context |
+| `Search` | Search Unity project using Unity Search API |
 | `NuGet.List` | List all installed NuGet packages (requires NuGetForUnity) |
 | `NuGet.Install` | Install a NuGet package (requires NuGetForUnity) |
 | `NuGet.Uninstall` | Uninstall a NuGet package (requires NuGetForUnity) |
@@ -184,6 +197,9 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `Recorder.StopRecording` | Stop the current video recording |
 | `Recorder.Status` | Get the current recording status |
 | `Screenshot.Capture` | Capture a screenshot of the Game View and save as PNG (requires Play Mode) |
+| `BuildMagic.List` | List all BuildMagic build schemes (requires BuildMagic) |
+| `BuildMagic.Inspect` | Inspect a build scheme's configurations (requires BuildMagic) |
+| `BuildMagic.Apply` | Apply a build scheme (requires BuildMagic) |
 | `Remote.List` | List debug commands registered on connected runtime player |
 | `Remote.Invoke` | Invoke a debug command on connected runtime player |
 | `Module.List` | List all available modules and their enabled status |
@@ -248,6 +264,14 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --target Andr
 unicli exec BuildPlayer.Compile --json
 unicli exec BuildPlayer.Compile --target Android --json
 unicli exec BuildPlayer.Compile --target iOS --extraScriptingDefines MY_DEFINE --extraScriptingDefines ANOTHER_DEFINE --json
+```
+
+**Get/switch the active build target:**
+
+```bash
+unicli exec BuildTarget.GetActive --json
+unicli exec BuildTarget.Switch --target Android --json
+unicli exec BuildTarget.Switch --target iOS --json
 ```
 
 **Manage build profiles (Unity 6+ only):**
@@ -366,6 +390,29 @@ unicli exec Scene.SetActive --name "Level1" --json
 unicli exec Scene.Save --all --json
 unicli exec Scene.Close --name "Additive" --json
 unicli exec Scene.New --empty --additive --json
+```
+
+**Selection operations:**
+
+```bash
+unicli exec Selection.Get --json
+unicli exec Selection.SetGameObject --path "Main Camera" --json
+unicli exec Selection.SetAsset --path "Assets/Materials/MyMat.mat" --json
+```
+
+**Window operations:**
+
+```bash
+unicli exec Window.List --json
+unicli exec Window.Open --typeName "UnityEditor.ConsoleWindow" --json
+unicli exec Window.Focus --typeName "UnityEditor.SceneView" --json
+```
+
+**Search Unity project:**
+
+```bash
+unicli exec Search --query "t:Material" --json
+unicli exec Search --query "t:Prefab" --maxResults 10 --json
 ```
 
 **Delete an asset:**
@@ -499,7 +546,7 @@ unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024,"limit":5}' --json
 unicli exec Module.List --json
 
 # Enable a module
-unicli exec Module.Enable '{"name":"Settings"}' --json
+unicli exec Module.Enable '{"name":"Search"}' --json
 
 # Disable a module
 unicli exec Module.Disable '{"name":"Profiler"}' --json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"
 
 # Module management
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.List --json
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.Enable '{"name":"Settings"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.Enable '{"name":"Search"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.Disable '{"name":"Profiler"}' --json
 
 # Compile Unity project (also serves as a build verification for the server)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ unicli exec BuildPlayer.Compile
 unicli exec BuildPlayer.Compile --target Android
 unicli exec BuildPlayer.Compile --target iOS --extraScriptingDefines MY_DEFINE --extraScriptingDefines ANOTHER_DEFINE
 
+# Get/switch the active build target
+unicli exec BuildTarget.GetActive
+unicli exec BuildTarget.Switch --target Android
+unicli exec BuildTarget.Switch --target iOS
+
+# Build profiles (Unity 6+ only)
+unicli exec BuildProfile.List
+unicli exec BuildProfile.GetActive
+unicli exec BuildProfile.SetActive '{"path":"Assets/Settings/MyProfile.asset"}'
+unicli exec BuildProfile.Inspect '{"path":"Assets/Settings/MyProfile.asset"}'
+
 # List available connection targets (players/devices)
 unicli exec Connection.List
 
@@ -277,6 +288,20 @@ unicli exec Prefab.Instantiate --assetPath "Assets/Prefabs/Enemy.prefab"
 unicli exec Prefab.Save --path "Player" --assetPath "Assets/Prefabs/Player.prefab"
 unicli exec Prefab.Apply --path "MyPrefabInstance"
 unicli exec Prefab.Unpack --path "MyPrefabInstance" --completely
+
+# Selection operations
+unicli exec Selection.Get
+unicli exec Selection.SetGameObject --path "Main Camera"
+unicli exec Selection.SetAsset --path "Assets/Materials/MyMat.mat"
+
+# Window operations
+unicli exec Window.List
+unicli exec Window.Open --typeName "UnityEditor.ConsoleWindow"
+unicli exec Window.Focus --typeName "UnityEditor.SceneView"
+
+# Search Unity project using Unity Search API
+unicli exec Search --query "t:Material"
+unicli exec Search --query "t:Prefab" --maxResults 10
 
 # Delete an asset
 unicli exec AssetDatabase.Delete --path "Assets/Prefabs/Old.prefab"
@@ -391,23 +416,39 @@ unicli exec Profiler.FindSpikes '{"frameTimeThresholdMs":16.6}' --json
 unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024,"limit":5}' --json
 ```
 
+**Screenshot and video recording:**
+
+```bash
+# Capture a screenshot (requires Play Mode)
+unicli exec Screenshot.Capture --json
+unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
+unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
+
+# Record video (requires Play Mode and com.unity.recorder)
+unicli exec Recorder.StartRecording --json
+unicli exec Recorder.StartRecording '{"path":"Recordings/demo.mp4","format":"MP4","frameRate":60}' --json
+unicli exec Recorder.Status --json
+unicli exec Recorder.StopRecording --json
+```
+
 **Module management:**
 
-UniCli groups optional commands into **modules** that can be toggled on or off per project. Core commands (Compile, Eval, Console, PlayMode, Menu, GameObject, Scene, PackageManager, etc.) are always available and cannot be disabled.
+UniCli groups optional commands into **modules** that can be toggled on or off per project. Core commands (Compile, Eval, Console, PlayMode, Menu, Build, TestRunner, Settings, etc.) are always available and cannot be disabled.
 
 The following modules are available:
 
 | Module | Description |
 |---|---|
-| Scene | Scene and GameObject operations |
-| Assets | AssetDatabase, Prefab, Component, Selection, Material operations |
-| Build | BuildPlayer, BuildProfile, TestRunner operations |
+| Scene | Scene operations |
+| GameObject | GameObject and Component operations |
+| Assets | AssetDatabase, Prefab, Material operations |
 | Profiler | Profiler operations |
 | Animation | Animator and AnimatorController operations |
-| Settings | PlayerSettings, EditorSettings, EditorUserBuildSettings operations |
 | Remote | Remote debug and Connection operations |
 | Recorder | Video recording operations (requires `com.unity.recorder`) |
+| Search | Unity Search API operations |
 | NuGet | NuGet package management (requires NuGetForUnity) |
+| BuildMagic | BuildMagic build scheme operations (requires `jp.co.cyberagent.buildmagic`) |
 
 All modules are enabled by default. To disable a module, use the CLI or the Unity settings UI (**Edit > Project Settings > UniCli**):
 
@@ -416,7 +457,7 @@ All modules are enabled by default. To disable a module, use the CLI or the Unit
 unicli exec Module.List --json
 
 # Enable a module
-unicli exec Module.Enable '{"name":"Settings"}' --json
+unicli exec Module.Enable '{"name":"Search"}' --json
 
 # Disable a module
 unicli exec Module.Disable '{"name":"Profiler"}' --json
@@ -452,6 +493,12 @@ The following commands are built in. You can also run `unicli commands` to see t
 |--------------------|--------------------------------------|------------------------------------|
 | BuildPlayer        | `BuildPlayer.Build`                  | Build the player                   |
 | BuildPlayer        | `BuildPlayer.Compile`                | Compile player scripts for a build target |
+| BuildProfile       | `BuildProfile.List`                  | List all build profiles (Unity 6+) |
+| BuildProfile       | `BuildProfile.GetActive`             | Get the active build profile (Unity 6+) |
+| BuildProfile       | `BuildProfile.SetActive`             | Set the active build profile (Unity 6+) |
+| BuildProfile       | `BuildProfile.Inspect`               | Inspect a build profile's details (Unity 6+) |
+| BuildTarget        | `BuildTarget.GetActive`              | Get the active build target and target group |
+| BuildTarget        | `BuildTarget.Switch`                 | Switch the active build target       |
 | Core               | `Compile`                            | Compile scripts and return results |
 | Connection         | `Connection.List`                    | List available connection targets  |
 | Connection         | `Connection.Connect`                 | Connect to a target by ID, IP, or device ID |
@@ -461,6 +508,7 @@ The following commands are built in. You can also run `unicli commands` to see t
 | PlayMode           | `PlayMode.Enter`                     | Enter play mode                    |
 | PlayMode           | `PlayMode.Exit`                      | Exit play mode                     |
 | PlayMode           | `PlayMode.Pause`                     | Toggle pause                       |
+| PlayMode           | `PlayMode.Status`                    | Get the current play mode state    |
 | Menu               | `Menu.List`                          | List menu items                    |
 | Menu               | `Menu.Execute`                       | Execute a menu item                |
 | TestRunner         | `TestRunner.RunEditMode`             | Run EditMode tests                 |
@@ -480,6 +528,7 @@ The following commands are built in. You can also run `unicli commands` to see t
 | GameObject         | `GameObject.SetParent`               | Change parent or move to root      |
 | Component          | `Component.SetProperty`              | Set a component property (supports ObjectReference via `guid:`, `instanceId:`, asset path) |
 | Material           | `Material.Create`                    | Create a new material asset        |
+| Material           | `Material.Inspect`                   | Read all properties of a material (auto-generated) |
 | Material           | `Material.SetColor`                  | Set a color property on a material |
 | Material           | `Material.GetColor`                  | Get a color property from a material |
 | Material           | `Material.SetFloat`                  | Set a float property on a material |
@@ -524,9 +573,19 @@ The following commands are built in. You can also run `unicli commands` to see t
 | Scene              | `Scene.Close`                        | Close a loaded scene               |
 | Scene              | `Scene.Save`                         | Save a scene or all open scenes    |
 | Scene              | `Scene.New`                          | Create a new scene                 |
+| Selection          | `Selection.Get`                      | Get the current editor selection   |
+| Selection          | `Selection.SetAsset`                 | Select an asset by path            |
+| Selection          | `Selection.SetAssets`                | Select multiple assets by paths    |
+| Selection          | `Selection.SetGameObject`            | Select a GameObject by path        |
+| Selection          | `Selection.SetGameObjects`           | Select multiple GameObjects by paths |
+| Window             | `Window.List`                        | List all available EditorWindow types |
+| Window             | `Window.Open`                        | Open an EditorWindow by type name  |
+| Window             | `Window.Focus`                       | Focus an already-open EditorWindow |
+| Window             | `Window.Create`                      | Create a new EditorWindow instance |
 | Utility            | `Type.List`                          | List types derived from a base type |
 | Utility            | `Type.Inspect`                       | Inspect nested types of a given type |
 | Eval               | `Eval`                               | Compile and execute C# code dynamically |
+| Search (optional)  | `Search`                             | Search Unity project using Unity Search API |
 | NuGet (optional)   | `NuGet.List`                         | List all installed NuGet packages  |
 | NuGet (optional)   | `NuGet.Install`                      | Install a NuGet package            |
 | NuGet (optional)   | `NuGet.Uninstall`                    | Uninstall a NuGet package          |
@@ -540,6 +599,15 @@ The following commands are built in. You can also run `unicli commands` to see t
 | Profiler           | `Profiler.TakeSnapshot`              | Take a memory snapshot (.snap file) |
 | Profiler           | `Profiler.AnalyzeFrames`             | Analyze recorded frames and return aggregate statistics |
 | Profiler           | `Profiler.FindSpikes`                | Find frames exceeding frame time or GC allocation thresholds |
+| Remote             | `Remote.List`                        | List debug commands on connected player |
+| Remote             | `Remote.Invoke`                      | Invoke a debug command on connected player |
+| Recorder (optional)| `Recorder.StartRecording`            | Start recording Game View as video (requires Play Mode) |
+| Recorder (optional)| `Recorder.StopRecording`             | Stop the current video recording   |
+| Recorder (optional)| `Recorder.Status`                    | Get the current recording status   |
+| Screenshot         | `Screenshot.Capture`                 | Capture Game View screenshot as PNG (requires Play Mode) |
+| BuildMagic (optional)| `BuildMagic.List`                  | List all BuildMagic build schemes  |
+| BuildMagic (optional)| `BuildMagic.Inspect`               | Inspect a build scheme's configurations |
+| BuildMagic (optional)| `BuildMagic.Apply`                 | Apply a build scheme               |
 | Module             | `Module.List`                        | List all available modules and their enabled status |
 | Module             | `Module.Enable`                      | Enable a module and reload the command dispatcher |
 | Module             | `Module.Disable`                     | Disable a module and reload the command dispatcher |


### PR DESCRIPTION
## Summary

- Add all missing commands to README.md Available Commands table and SKILL.md Built-in Commands table:
  - BuildProfile.*, BuildTarget.GetActive, BuildTarget.Switch, PlayMode.Status
  - Selection.* (Get, SetAsset, SetAssets, SetGameObject, SetGameObjects)
  - Window.* (List, Open, Focus, Create)
  - Search, Remote.List, Remote.Invoke
  - Recorder.* (StartRecording, StopRecording, Status)
  - Screenshot.Capture, Material.Inspect
  - BuildMagic.* (List, Inspect, Apply)
- Update module table: remove Build/Settings (consolidated as core), add Search and BuildMagic
- Add examples for new commands (BuildTarget, Selection, Window, Search, Screenshot, Recorder)
- Fix Module.Enable example to use "Search" instead of removed "Settings" module

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify SKILL.md renders correctly
- [ ] Cross-check command list against `unicli commands` output