### PR TITLE
Release v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>0.11.1</Version>
+    <Version>0.12.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CommandDispatcher.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CommandDispatcher.cs
@@ -21,7 +21,7 @@ namespace UniCli.Server.Editor
         private static readonly string ServerVersion = ResolveServerVersion();
 
         // Update on release: clients older than this version will be rejected
-        private const string MinimumClientVersion = "0.11.1";
+        private const string MinimumClientVersion = "0.12.0";
 
         private static string ResolveServerVersion()
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor拡張機能 - CLIからUnityを操作するためのサーバー",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary

Bump version to 0.12.0 for release.

### Changes since v0.11.1

- Modularize Module handlers with dependency injection (PR #67)
- Fix RemoteLinkerProcessor to conditionally generate link.xml (PR #68)
- Extract Search command into separate assembly with module support (PR #69)
- Add BuildTarget.GetActive and BuildTarget.Switch commands (PR #70)
- Update README and SKILL.md with all available commands (PR #71)

### Version bumps

- `src/UniCli.Client/UniCli.Client.csproj`: 0.11.1 → 0.12.0
- `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json`: 0.11.1 → 0.12.0
- `.claude-plugin/marketplace.json`: 0.11.1 → 0.12.0