### PR TITLE
Migrate module settings storage to EditorUserSettings

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CoreServiceInstaller.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/CoreServiceInstaller.cs
@@ -9,7 +9,7 @@ namespace UniCli.Server.Editor
             var pipeName = ProjectIdentifier.GetPipeName();
             services.AddSingleton(new ServerContext(pipeName));
 
-            services.AddSingleton(UniCliSettings.instance);
+            services.AddSingleton(new UniCliSettings());
             services.AddSingleton<IDispatcherReloader>(new BootstrapDispatcherReloader());
         }
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/UniCliSettingsProvider.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/UniCliSettingsProvider.cs
@@ -18,7 +18,7 @@ namespace UniCli.Server.Editor
 
         public override void OnGUI(string searchContext)
         {
-            var settings = UniCliSettings.instance;
+            var settings = new UniCliSettings();
             var allNames = settings.DiscoverAllModuleNames();
             var commandsByModule = ModuleCommandScanner.GetCommandsByModule();
 


### PR DESCRIPTION
## Summary
- Replace `ScriptableSingleton<UniCliSettings>` with plain class backed by `EditorUserSettings.GetConfigValue`/`SetConfigValue`
- Module enable/disable state is now stored in `UserSettings/EditorUserSettings.asset` (gitignored by default) instead of `ProjectSettings/UniCliSettings.asset`, eliminating unnecessary git diffs
- Remove static singleton instance and in-memory cache — each access reads directly from `EditorUserSettings`, keeping multiple instances consistent

## Test plan
- [x] `Compile` succeeds with no new errors
- [x] `Module.Disable` / `Module.Enable` persist correctly across calls
- [x] `Module.List` reflects changes immediately
- [x] All EditMode tests pass (39/39)