### PR TITLE
Show command execution status and queue in EditorWindow

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
@@ -17,6 +17,9 @@ namespace UniCli.Server.Editor
         public static ServiceRegistry Services { get; } = new();
         public static CommandDispatcher? Dispatcher => _dispatcher;
         public static bool IsRunning => _server != null;
+        public static string? CurrentCommandName => _server?.CurrentCommandName;
+        public static DateTime? CurrentCommandStartTime => _server?.CurrentCommandStartTime;
+        public static string[] QueuedCommandNames => _server?.QueuedCommandNames ?? Array.Empty<string>();
 
         static UniCliServerBootstrap()
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerWindow.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerWindow.cs
@@ -43,17 +43,47 @@ namespace UniCli.Server.Editor
             using (new EditorGUILayout.VerticalScope("box"))
             {
                 var isRunning = UniCliServerBootstrap.IsRunning;
-                var statusLabel = isRunning ? "\u25cf Running" : "\u25cf Stopped";
-                var statusColor = isRunning ? new Color(0.2f, 0.8f, 0.2f) : new Color(0.9f, 0.3f, 0.3f);
+                var commandName = UniCliServerBootstrap.CurrentCommandName;
+                var startTime = UniCliServerBootstrap.CurrentCommandStartTime;
 
-                var style = new GUIStyle(EditorStyles.label) { fontStyle = FontStyle.Bold };
+                var statusStyle = new GUIStyle(EditorStyles.label) { fontStyle = FontStyle.Bold };
                 var prevColor = GUI.contentColor;
-                GUI.contentColor = statusColor;
-                EditorGUILayout.LabelField(statusLabel, style);
+
+                if (!isRunning)
+                {
+                    GUI.contentColor = new Color(0.9f, 0.3f, 0.3f);
+                    EditorGUILayout.LabelField("\u25cf Stopped", statusStyle);
+                }
+                else if (commandName != null && startTime.HasValue)
+                {
+                    var elapsed = (DateTime.UtcNow - startTime.Value).TotalSeconds;
+                    var dotCount = (int)(EditorApplication.timeSinceStartup * 2) % 3 + 1;
+                    var dots = new string('.', dotCount);
+
+                    GUI.contentColor = new Color(1.0f, 0.7f, 0.2f);
+                    EditorGUILayout.LabelField($"\u25cf Running \u2014 {commandName} ({elapsed:F1}s){dots}", statusStyle);
+                }
+                else
+                {
+                    GUI.contentColor = new Color(0.2f, 0.8f, 0.2f);
+                    EditorGUILayout.LabelField("\u25cf Running", statusStyle);
+                }
+
                 GUI.contentColor = prevColor;
 
                 EditorGUILayout.LabelField("Project", Application.dataPath);
                 EditorGUILayout.LabelField("Pipe", ProjectIdentifier.GetPipeName());
+
+                if (isRunning)
+                {
+                    var queued = UniCliServerBootstrap.QueuedCommandNames;
+                    if (queued.Length > 0)
+                    {
+                        EditorGUILayout.Space(2);
+                        var queueLabel = $"Queued ({queued.Length}): {string.Join(", ", queued)}";
+                        EditorGUILayout.LabelField(queueLabel, EditorStyles.miniLabel);
+                    }
+                }
 
                 EditorGUILayout.Space(2);
 


### PR DESCRIPTION
## Summary
- Display the currently executing command name with elapsed time directly in the server status line (e.g., `● Running — Compile (2.3s)...`)
- Show queued command names when multiple commands are waiting to be processed (e.g., `Queued (3): Scene.List, Compile, ...`)
- Animated dots indicate ongoing execution; status line returns to `● Running` when idle

## Changes
- **UniCliServer**: Added `CurrentCommandName`, `CurrentCommandStartTime`, and `QueuedCommandNames` properties to track execution state
- **UniCliServerBootstrap**: Added static proxy properties for window access
- **UniCliServerWindow**: Integrated command activity into the status line and added queue display

## Test plan
- [x] Unity compilation passes (`exec Compile`)
- [x] EditMode tests pass (39/39)
- [x] Verified with long-running async command (`eval` with `Task.Delay(15000)`)
- [x] Verified with heavy commands (`BuildPlayer.Compile`, `TestRunner.RunEditMode/PlayMode`)
- [x] Visual confirmation: open Window > UniCli Server and run a command to see real-time status