### PR TITLE
Fix pipe name hash mismatch on Windows

### DIFF
--- a/src/UniCli.Client.Tests/ProjectIdentifierTests.cs
+++ b/src/UniCli.Client.Tests/ProjectIdentifierTests.cs
@@ -1,0 +1,73 @@
+using UniCli.Client;
+
+namespace UniCli.Client.Tests;
+
+public class NormalizePathForHashTests
+{
+    [Fact]
+    public void BackslashesAreReplacedWithForwardSlashes()
+    {
+        var result = ProjectIdentifier.NormalizePathForHash(@"C:\Users\dev\MyProject\Assets");
+
+        Assert.Equal("C:/Users/dev/MyProject/Assets", result);
+    }
+
+    [Fact]
+    public void ForwardSlashesArePreserved()
+    {
+        var result = ProjectIdentifier.NormalizePathForHash("C:/Users/dev/MyProject/Assets");
+
+        Assert.Equal("C:/Users/dev/MyProject/Assets", result);
+    }
+
+    [Fact]
+    public void MixedSeparatorsAreNormalized()
+    {
+        var result = ProjectIdentifier.NormalizePathForHash(@"C:\Users/dev\MyProject/Assets");
+
+        Assert.Equal("C:/Users/dev/MyProject/Assets", result);
+    }
+}
+
+public class GetProjectHashTests
+{
+    [Fact]
+    public void SamePathWithDifferentSeparators_ProducesSameHash()
+    {
+        var hashForward = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash("C:/Users/dev/MyProject/Assets"));
+        var hashBackslash = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash(@"C:\Users\dev\MyProject\Assets"));
+
+        Assert.Equal(hashForward, hashBackslash);
+    }
+
+    [Fact]
+    public void DifferentPaths_ProduceDifferentHashes()
+    {
+        var hash1 = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash("C:/Users/dev/ProjectA/Assets"));
+        var hash2 = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash("C:/Users/dev/ProjectB/Assets"));
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashIsEightCharacters()
+    {
+        var hash = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash("/Users/dev/MyProject/Assets"));
+
+        Assert.Equal(8, hash.Length);
+    }
+
+    [Fact]
+    public void HashIsLowercaseHex()
+    {
+        var hash = ProjectIdentifier.GetProjectHash(
+            ProjectIdentifier.NormalizePathForHash("/Users/dev/MyProject/Assets"));
+
+        Assert.Matches("^[0-9a-f]{8}$", hash);
+    }
+}

--- a/src/UniCli.Client/CompletionCache.cs
+++ b/src/UniCli.Client/CompletionCache.cs
@@ -9,7 +9,8 @@ internal static class CompletionCache
 {
     public static string GetCacheDir(string projectRoot)
     {
-        var hash = ProjectIdentifier.GetProjectHash(projectRoot);
+        var normalized = ProjectIdentifier.NormalizeToDataPath(projectRoot);
+        var hash = ProjectIdentifier.GetProjectHash(normalized);
 
         if (OperatingSystem.IsWindows())
         {

--- a/src/UniCli.Client/ProjectIdentifier.cs
+++ b/src/UniCli.Client/ProjectIdentifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -42,7 +43,17 @@ namespace UniCli.Client
                 fullPath = Path.Combine(trimmed, "Assets");
             }
 
-            return fullPath;
+            return NormalizePathForHash(fullPath);
+        }
+
+        internal static string NormalizePathForHash(string path)
+        {
+            path = path.Replace('\\', '/');
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                path = path.ToLowerInvariant();
+
+            return path;
         }
 
         /// <summary>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ProjectIdentifier.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ProjectIdentifier.cs
@@ -9,13 +9,23 @@ namespace UniCli.Server.Editor
     {
         private static string GetProjectHash()
         {
-            var projectPath = Application.dataPath;
+            var projectPath = NormalizePathForHash(Application.dataPath);
 
             using var sha256 = SHA256.Create();
             var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(projectPath));
             var hash = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
 
             return hash.Substring(0, 8);
+        }
+
+        internal static string NormalizePathForHash(string path)
+        {
+            path = path.Replace('\\', '/');
+
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+                path = path.ToLowerInvariant();
+
+            return path;
         }
 
         public static string GetPipeName()


### PR DESCRIPTION
## Summary
- Normalize paths before hashing on both client and server sides to fix pipe name mismatch on Windows
- Replace backslashes with forward slashes to match Unity's `Application.dataPath` convention
- Lowercase paths on Windows to handle case-insensitive filesystem
- Fix `CompletionCache` bypassing path normalization, which could cause cache fragmentation

## Root Cause
On Windows, Unity's `Application.dataPath` uses forward slashes (e.g., `C:/Users/dev/Project/Assets`), while the CLI's `Path.GetFullPath` returns backslashes (e.g., `C:\Users\dev\Project\Assets`). Additionally, drive letter and directory casing can differ. Both issues cause different SHA256 hashes, resulting in mismatched pipe names.

## Changes
- **Server `ProjectIdentifier`**: Added `NormalizePathForHash` — replaces `\` with `/`, lowercases on Windows
- **Client `ProjectIdentifier`**: Added matching `NormalizePathForHash`, applied in `NormalizeToDataPath`
- **Client `CompletionCache`**: Now normalizes path before hashing (was using raw `projectRoot`)
- **Tests**: Added `ProjectIdentifierTests` covering separator normalization and hash consistency

## Test plan
- [x] Client unit tests pass (42/42)
- [x] Unity compilation passes
- [x] Unity EditMode tests pass (39/39)

## Note
Symlink resolution is not addressed here — `Path.GetFullPath` does not resolve symlinks, while Unity may return the real path. This is a rare edge case and can be addressed if reported.