### PR TITLE
Add stackTraceLines option to test runner and console log commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,17 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --json
 # Run tests with all results (including passed)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter all --json
 
+# Run tests with stack traces (first 3 lines per failure)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --stackTraceLines 3 --json
+
 # Run tests with summary counts only (no individual results)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json
 
 # Console logs filtered by type (comma-separated)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog --logType "Warning,Error" --json
+
+# Console logs with stack traces (first 3 lines)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog --logType Error --stackTraceLines 3 --json
 
 # Build player
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --json

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ unicli exec TestRunner.RunEditMode --testNameFilter MyTest
 # Include all results (including passed)
 unicli exec TestRunner.RunEditMode --resultFilter all
 
+# Include stack traces for failures (first 3 lines)
+unicli exec TestRunner.RunEditMode --stackTraceLines 3
+
+# Full stack traces
+unicli exec TestRunner.RunEditMode --stackTraceLines -1
+
 # Summary counts only (no individual results)
 unicli exec TestRunner.RunEditMode --resultFilter none
 
@@ -345,6 +351,7 @@ unicli exec Menu.Execute --menuPath "Window/General/Console"
 # Console logs
 unicli exec Console.GetLog
 unicli exec Console.GetLog --logType "Warning,Error"  # filter by multiple types
+unicli exec Console.GetLog --logType Error --stackTraceLines 3  # with first 3 stack trace lines
 unicli exec Console.Clear
 
 # Dynamic C# code execution (Eval)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Console/EditorLogHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Console/EditorLogHandler.cs
@@ -20,6 +20,14 @@ namespace UniCli.Server.Editor.Handlers
         {
             var logs = _logManager.GetLogs(request.logType, request.searchText, request.maxCount);
 
+            if (request.stackTraceLines >= 0)
+            {
+                for (var i = 0; i < logs.Length; i++)
+                {
+                    logs[i].stackTrace = StackTraceHelper.Truncate(logs[i].stackTrace, request.stackTraceLines);
+                }
+            }
+
             var response = new EditorLogResponse
             {
                 logs = logs,
@@ -37,5 +45,6 @@ namespace UniCli.Server.Editor.Handlers
         public string logType = "All";
         public string searchText = "";
         public int maxCount = 100;
+        public int stackTraceLines = 0; // 0: no stack trace (default), -1: full, N>0: first N lines
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/StackTraceHelper.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/StackTraceHelper.cs
@@ -1,0 +1,41 @@
+namespace UniCli.Server.Editor
+{
+    internal static class StackTraceHelper
+    {
+        /// <summary>
+        /// Truncate a stack trace to the specified number of lines.
+        /// lines &lt; 0: return full stack trace, 0: return empty string, N &gt; 0: return first N lines.
+        /// </summary>
+        public static string Truncate(string stackTrace, int lines)
+        {
+            if (string.IsNullOrEmpty(stackTrace))
+                return "";
+
+            if (lines < 0)
+                return stackTrace;
+
+            if (lines == 0)
+                return "";
+
+            var count = 0;
+            var endIndex = 0;
+            for (var i = 0; i < stackTrace.Length; i++)
+            {
+                if (stackTrace[i] != '\n')
+                    continue;
+
+                count++;
+                if (count >= lines)
+                {
+                    endIndex = i;
+                    break;
+                }
+            }
+
+            if (count < lines)
+                return stackTrace;
+
+            return stackTrace.Substring(0, endIndex);
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/StackTraceHelper.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/StackTraceHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c09cdd1c6fa540dcb688ee98c992ce7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `stackTraceLines` parameter to `TestRunner.RunEditMode` / `TestRunner.RunPlayMode` and `Console.GetLog`
  - `0` (default): omit stack traces entirely — keeps output compact for AI workflows
  - `N > 0`: include first N lines of each stack trace
  - `-1`: include full stack trace
- Add shared `StackTraceHelper.Truncate` utility for consistent truncation logic

## Test plan
- [x] Verified default (`stackTraceLines=0`) omits stack traces from test results
- [x] Verified `--stackTraceLines 2` truncates console log stack traces to 2 lines
- [x] Verified `--stackTraceLines -1` returns full stack traces
- [x] Unity compilation passes with no errors
- [x] All EditMode tests pass (39/39)