### PR TITLE
Add NuGet source management commands

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -186,6 +186,9 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 | `NuGet.Install` | Install a NuGet package (requires NuGetForUnity) |
 | `NuGet.Uninstall` | Uninstall a NuGet package (requires NuGetForUnity) |
 | `NuGet.Restore` | Restore all NuGet packages (requires NuGetForUnity) |
+| `NuGet.ListSources` | List all configured package sources (requires NuGetForUnity) |
+| `NuGet.AddSource` | Add a NuGet package source (requires NuGetForUnity) |
+| `NuGet.RemoveSource` | Remove a NuGet package source (requires NuGetForUnity) |
 | `Profiler.Inspect` | Get profiler status and memory statistics |
 | `Profiler.StartRecording` | Start profiler recording |
 | `Profiler.StopRecording` | Stop profiler recording |
@@ -534,11 +537,23 @@ unicli exec NuGet.List --json
 unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
 unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
 
+# Install from a local package source
+unicli exec NuGet.Install '{"id":"MyPackage","source":"/path/to/local/feed"}' --json
+
 # Uninstall a NuGet package
 unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
 
 # Restore all NuGet packages
 unicli exec NuGet.Restore --json
+
+# List configured package sources
+unicli exec NuGet.ListSources --json
+
+# Add a package source
+unicli exec NuGet.AddSource '{"name":"LocalFeed","path":"/path/to/local/feed"}' --json
+
+# Remove a package source
+unicli exec NuGet.RemoveSource '{"name":"LocalFeed"}' --json
 ```
 
 **Profiler operations:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,12 @@ EOF
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.List --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Install '{"id":"MyPackage","source":"/path/to/local/feed"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.Restore --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.ListSources --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.AddSource '{"name":"LocalFeed","path":"/path/to/local/feed"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec NuGet.RemoveSource '{"name":"LocalFeed"}' --json
 
 # Profiler operations
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.Inspect --json

--- a/README.md
+++ b/README.md
@@ -491,11 +491,23 @@ unicli exec NuGet.List --json
 unicli exec NuGet.Install '{"id":"Newtonsoft.Json"}' --json
 unicli exec NuGet.Install '{"id":"Newtonsoft.Json","version":"13.0.3"}' --json
 
+# Install from a local package source
+unicli exec NuGet.Install '{"id":"MyPackage","source":"/path/to/local/feed"}' --json
+
 # Uninstall a NuGet package
 unicli exec NuGet.Uninstall '{"id":"Newtonsoft.Json"}' --json
 
 # Restore all NuGet packages
 unicli exec NuGet.Restore --json
+
+# List configured package sources
+unicli exec NuGet.ListSources --json
+
+# Add a package source
+unicli exec NuGet.AddSource '{"name":"LocalFeed","path":"/path/to/local/feed"}' --json
+
+# Remove a package source
+unicli exec NuGet.RemoveSource '{"name":"LocalFeed"}' --json
 ```
 
 
@@ -604,6 +616,9 @@ The following commands are built in. You can also run `unicli commands` to see t
 | NuGet (optional)   | `NuGet.Install`                      | Install a NuGet package            |
 | NuGet (optional)   | `NuGet.Uninstall`                    | Uninstall a NuGet package          |
 | NuGet (optional)   | `NuGet.Restore`                      | Restore all NuGet packages         |
+| NuGet (optional)   | `NuGet.ListSources`                  | List all configured package sources |
+| NuGet (optional)   | `NuGet.AddSource`                    | Add a NuGet package source         |
+| NuGet (optional)   | `NuGet.RemoveSource`                 | Remove a NuGet package source      |
 | Profiler           | `Profiler.Inspect`                   | Get profiler status and memory statistics |
 | Profiler           | `Profiler.StartRecording`            | Start profiler recording           |
 | Profiler           | `Profiler.StopRecording`             | Stop profiler recording            |

--- a/src/UniCli.Unity/Assets/NuGet.config
+++ b/src/UniCli.Unity/Assets/NuGet.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" enableCredentialProvider="false" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
+  <packageSourceCredentials />
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetAddSourceHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetAddSourceHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    [Module("NuGet")]
+    public sealed class NuGetAddSourceHandler : CommandHandler<NuGetAddSourceRequest, NuGetAddSourceResponse>
+    {
+        public override string CommandName => "NuGet.AddSource";
+        public override string Description => "Add a NuGet package source";
+
+        protected override bool TryWriteFormatted(NuGetAddSourceResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Added source '{response.name}' ({response.path})"
+                : "Failed to add source");
+            return true;
+        }
+
+        protected override ValueTask<NuGetAddSourceResponse> ExecuteAsync(NuGetAddSourceRequest request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+            if (string.IsNullOrEmpty(request.path))
+                throw new ArgumentException("path is required");
+
+            NuGetConfigHelper.AddSource(request.name, request.path);
+
+            return new ValueTask<NuGetAddSourceResponse>(new NuGetAddSourceResponse
+            {
+                name = request.name,
+                path = request.path,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetAddSourceRequest
+    {
+        public string name;
+        public string path;
+    }
+
+    [Serializable]
+    public class NuGetAddSourceResponse
+    {
+        public string name;
+        public string path;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetAddSourceHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetAddSourceHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9820e8484147415885c6cbf6614072a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetConfigHelper.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetConfigHelper.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NugetForUnity.Configuration;
+using NugetForUnity.PackageSource;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    internal static class NuGetConfigHelper
+    {
+        private static readonly MethodInfo CreatePackageSourceMethod;
+
+        static NuGetConfigHelper()
+        {
+            var creatorType = typeof(INugetPackageSource).Assembly
+                .GetType("NugetForUnity.PackageSource.NugetPackageSourceCreator");
+
+            CreatePackageSourceMethod = creatorType?.GetMethod(
+                "CreatePackageSource",
+                BindingFlags.Public | BindingFlags.Static);
+
+            if (CreatePackageSourceMethod == null)
+                throw new InvalidOperationException(
+                    "NugetPackageSourceCreator.CreatePackageSource not found. NuGetForUnity version may be incompatible.");
+        }
+
+        public static void AddSource(string name, string path)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("name is required");
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentException("path is required");
+
+            var config = ConfigurationManager.NugetConfigFile;
+
+            var existing = config.PackageSources
+                .FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+                throw new InvalidOperationException($"Package source '{name}' already exists");
+
+            var source = (INugetPackageSource)CreatePackageSourceMethod.Invoke(
+                null,
+                new object[] { name, path, null, config.PackageSources });
+
+            config.PackageSources.Add(source);
+            config.Save(ConfigurationManager.NugetConfigFilePath);
+            ConfigurationManager.LoadNugetConfigFile();
+        }
+
+        public static void RemoveSource(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("name is required");
+
+            var config = ConfigurationManager.NugetConfigFile;
+
+            var source = config.PackageSources
+                .FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (source == null)
+                throw new InvalidOperationException($"Package source '{name}' not found");
+
+            config.PackageSources.Remove(source);
+            config.Save(ConfigurationManager.NugetConfigFilePath);
+            ConfigurationManager.LoadNugetConfigFile();
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetConfigHelper.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetConfigHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdd51aabcbd849d489da3d105ca22ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListSourcesHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListSourcesHandler.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NugetForUnity.Configuration;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    [Module("NuGet")]
+    public sealed class NuGetListSourcesHandler : CommandHandler<Unit, NuGetListSourcesResponse>
+    {
+        public override string CommandName => "NuGet.ListSources";
+        public override string Description => "List all configured NuGet package sources";
+
+        protected override bool TryWriteFormatted(NuGetListSourcesResponse response, bool success, IFormatWriter writer)
+        {
+            var nameWidth = "Name".Length;
+            var pathWidth = "Path".Length;
+
+            foreach (var src in response.sources)
+            {
+                nameWidth = Math.Max(nameWidth, src.name.Length);
+                pathWidth = Math.Max(pathWidth, src.path.Length);
+            }
+
+            writer.WriteLine($"{"Name".PadRight(nameWidth)}  {"Path".PadRight(pathWidth)}  Enabled");
+
+            foreach (var src in response.sources)
+            {
+                writer.WriteLine($"{src.name.PadRight(nameWidth)}  {src.path.PadRight(pathWidth)}  {src.isEnabled}");
+            }
+
+            writer.WriteLine($"{response.totalCount} source(s)");
+
+            return true;
+        }
+
+        protected override ValueTask<NuGetListSourcesResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            var sources = ConfigurationManager.NugetConfigFile.PackageSources
+                .Select(s => new NuGetSourceEntry
+                {
+                    name = s.Name,
+                    path = s.SavedPath,
+                    isEnabled = s.IsEnabled,
+                })
+                .ToArray();
+
+            return new ValueTask<NuGetListSourcesResponse>(new NuGetListSourcesResponse
+            {
+                sources = sources,
+                totalCount = sources.Length,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetListSourcesResponse
+    {
+        public NuGetSourceEntry[] sources;
+        public int totalCount;
+    }
+
+    [Serializable]
+    public class NuGetSourceEntry
+    {
+        public string name;
+        public string path;
+        public bool isEnabled;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListSourcesHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetListSourcesHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ccce0531caf34b9e8360411fc0648ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRemoveSourceHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRemoveSourceHandler.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers.NuGetForUnity
+{
+    [Module("NuGet")]
+    public sealed class NuGetRemoveSourceHandler : CommandHandler<NuGetRemoveSourceRequest, NuGetRemoveSourceResponse>
+    {
+        public override string CommandName => "NuGet.RemoveSource";
+        public override string Description => "Remove a NuGet package source";
+
+        protected override bool TryWriteFormatted(NuGetRemoveSourceResponse response, bool success, IFormatWriter writer)
+        {
+            writer.WriteLine(success
+                ? $"Removed source '{response.name}'"
+                : "Failed to remove source");
+            return true;
+        }
+
+        protected override ValueTask<NuGetRemoveSourceResponse> ExecuteAsync(NuGetRemoveSourceRequest request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(request.name))
+                throw new ArgumentException("name is required");
+
+            NuGetConfigHelper.RemoveSource(request.name);
+
+            return new ValueTask<NuGetRemoveSourceResponse>(new NuGetRemoveSourceResponse
+            {
+                name = request.name,
+            });
+        }
+    }
+
+    [Serializable]
+    public class NuGetRemoveSourceRequest
+    {
+        public string name;
+    }
+
+    [Serializable]
+    public class NuGetRemoveSourceResponse
+    {
+        public string name;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRemoveSourceHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/NuGetForUnity/NuGetRemoveSourceHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd606d4f0cabd485db795be998f223b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `NuGet.ListSources`, `NuGet.AddSource`, `NuGet.RemoveSource` commands for managing NuGet package sources from the CLI
- Add `source` field to `NuGet.Install` for one-off installs from a local/custom feed (temporary source added during install, cleaned up in `finally`)
- `NuGetConfigHelper` uses reflection to call NuGetForUnity's internal `NugetPackageSourceCreator.CreatePackageSource`, then persists via `NugetConfigFile.Save()` + `ConfigurationManager.LoadNugetConfigFile()`

## Test plan
- [x] Unity compilation passes (`exec Compile`)
- [x] EditMode tests pass (39/39)
- [x] `NuGet.ListSources` returns current sources
- [x] `NuGet.AddSource` adds a source and `ListSources` reflects the change
- [x] `NuGet.RemoveSource` removes a source and `ListSources` reflects the change
- [x] Full round-trip verified: ListSources → AddSource → ListSources → RemoveSource → ListSources