### PR TITLE
Add Codex / Agent Skills integration

### DIFF
--- a/.agents/skills/unity-development
+++ b/.agents/skills/unity-development
@@ -1,0 +1,1 @@
+../../.claude-plugin/unicli/skills/unity-development

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: unity-development
 description: >-
   MUST activate when performing ANY Unity-related task: editing C# scripts
   under Assets/ or Packages/, compiling Unity code, running tests, creating or
@@ -7,6 +8,11 @@ description: >-
   operation involving the Unity Editor. This skill provides required workflows
   such as .meta file generation after file creation and compilation verification
   after code changes. Always load this skill before starting Unity work.
+license: MIT
+compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
+metadata:
+  author: yucchiy
+  version: "0.14.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/unicli/skills/unity-development/agents/openai.yaml
+++ b/.claude-plugin/unicli/skills/unity-development/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "UniCli — Unity Editor CLI"
+  short_description: "Control Unity Editor from the terminal via UniCli CLI"
+
+policy:
+  allow_implicit_invocation: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,10 +287,11 @@ When creating new commands, follow the naming conventions in `doc/command-naming
 ### Releasing a new version
 
 1. Create a `release/vX.Y.Z` branch from `main`
-2. Bump version in the following 3 files:
+2. Bump version in the following 4 files:
    - `src/UniCli.Client/UniCli.Client.csproj` (`<Version>`)
    - `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json` (`"version"`)
    - `.claude-plugin/marketplace.json` (`"version"`)
+   - `.claude-plugin/unicli/skills/unity-development/SKILL.md` (`metadata.version`)
 3. Build and verify: `dotnet build src/UniCli.Protocol && dotnet publish src/UniCli.Client -o .build`
 4. Create a PR to `main` with a changelog summary
 5. After merge: `git tag vX.Y.Z && git push origin vX.Y.Z`

--- a/README.md
+++ b/README.md
@@ -924,6 +924,33 @@ The UniCli CLI must be installed beforehand. See [Installation — CLI](#cli) ab
 /plugin install unicli@unicli
 ```
 
+## Agent Skills / Codex Integration
+
+UniCli's skill definition follows the [Agent Skills](https://github.com/anthropics/agent-skills) specification, making it compatible with multiple AI coding agents:
+
+- **Codex (OpenAI)**: Automatically detected via `.agents/skills/unity-development/` (symlinked to the canonical skill definition)
+- **Claude Code**: Installed as a plugin via `.claude-plugin/`
+- **Other agents**: Any tool that supports the Agent Skills spec can load the skill from `.agents/skills/`
+
+### Install via Codex `$skill-installer`
+
+If you're using [Codex](https://openai.com/index/introducing-codex/), install the UniCli skill directly from this repository:
+
+```
+$skill-installer install https://github.com/yucchiy/UniCli/tree/main/.agents/skills/unity-development
+```
+
+Once installed, Codex automatically detects the skill and gains the ability to interact with Unity Editor.
+
+### Manual setup for other projects
+
+To use UniCli's skill in another project, symlink or copy the skill directory:
+
+```bash
+mkdir -p .agents/skills
+ln -s /path/to/UniCli/.claude-plugin/unicli/skills/unity-development .agents/skills/unity-development
+```
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
## Summary
- Add `.agents/skills/unity-development` symlink for automatic Codex skill detection when the repo is cloned
- Add `agents/openai.yaml` with display name, description, and implicit invocation policy
- Add skill metadata (`name`, `license`, `author`, `version`) to SKILL.md frontmatter for `$skill-installer` compatibility
- Add "Agent Skills / Codex Integration" section to README with `$skill-installer` install instructions and manual setup guide
- Update release checklist in CLAUDE.md to include SKILL.md `metadata.version` bump (now 4 files)

## Test plan
- [ ] Verify `.agents/skills/unity-development` symlink resolves correctly after clone
- [ ] Verify `$skill-installer install https://github.com/yucchiy/UniCli/tree/main/.agents/skills/unity-development` installs the skill in Codex
- [ ] Confirm SKILL.md frontmatter parses correctly (name, license, metadata fields)
- [ ] Review README rendering on GitHub