### PR TITLE
Add automatic Scoop and Homebrew updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,103 @@ jobs:
             unicli-osx-arm64.tar.gz \
             unicli-osx-x64.tar.gz \
             unicli-win-x64.zip
+
+      - name: Update Scoop manifest
+        env:
+          GH_TOKEN: ${{ secrets.UNICLI_RELEASE_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA256=$(sha256sum unicli-win-x64.zip | awk '{print $1}')
+
+          cat > /tmp/unicli.json <<EOF
+          {
+            "version": "${VERSION}",
+            "description": "A command-line interface for controlling Unity Editor from the terminal",
+            "homepage": "https://github.com/yucchiy/UniCli",
+            "license": "MIT",
+            "architecture": {
+              "64bit": {
+                "url": "https://github.com/yucchiy/UniCli/releases/download/v${VERSION}/unicli-win-x64.zip",
+                "hash": "${SHA256}"
+              }
+            },
+            "bin": "unicli.exe",
+            "checkver": {
+              "github": "https://github.com/yucchiy/UniCli"
+            },
+            "autoupdate": {
+              "architecture": {
+                "64bit": {
+                  "url": "https://github.com/yucchiy/UniCli/releases/download/v\$version/unicli-win-x64.zip"
+                }
+              }
+            }
+          }
+          EOF
+
+          CONTENT=$(base64 -w 0 /tmp/unicli.json)
+          SHA=$(gh api repos/yucchiy/scoop-bucket/contents/bucket/unicli.json --jq '.sha' 2>/dev/null || echo "")
+
+          if [ -n "$SHA" ]; then
+            gh api repos/yucchiy/scoop-bucket/contents/bucket/unicli.json \
+              --method PUT \
+              --field message="Update unicli to v${VERSION}" \
+              --field content="$CONTENT" \
+              --field sha="$SHA"
+          else
+            gh api repos/yucchiy/scoop-bucket/contents/bucket/unicli.json \
+              --method PUT \
+              --field message="Add unicli v${VERSION}" \
+              --field content="$CONTENT"
+          fi
+
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.UNICLI_RELEASE_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA256_ARM64=$(sha256sum unicli-osx-arm64.tar.gz | awk '{print $1}')
+          SHA256_X64=$(sha256sum unicli-osx-x64.tar.gz | awk '{print $1}')
+
+          cat > /tmp/unicli.rb <<FORMULA
+          class Unicli < Formula
+            desc "CLI tool to control Unity Editor from the terminal"
+            homepage "https://github.com/yucchiy/UniCli"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/yucchiy/UniCli/releases/download/v#{version}/unicli-osx-arm64.tar.gz"
+                sha256 "${SHA256_ARM64}"
+              else
+                url "https://github.com/yucchiy/UniCli/releases/download/v#{version}/unicli-osx-x64.tar.gz"
+                sha256 "${SHA256_X64}"
+              end
+            end
+
+            def install
+              bin.install "unicli"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/unicli --version")
+            end
+          end
+          FORMULA
+
+          CONTENT=$(base64 -w 0 /tmp/unicli.rb)
+          SHA=$(gh api repos/yucchiy/homebrew-tap/contents/Formula/unicli.rb --jq '.sha' 2>/dev/null || echo "")
+
+          if [ -n "$SHA" ]; then
+            gh api repos/yucchiy/homebrew-tap/contents/Formula/unicli.rb \
+              --method PUT \
+              --field message="Update unicli to v${VERSION}" \
+              --field content="$CONTENT" \
+              --field sha="$SHA"
+          else
+            gh api repos/yucchiy/homebrew-tap/contents/Formula/unicli.rb \
+              --method PUT \
+              --field message="Add unicli v${VERSION}" \
+              --field content="$CONTENT"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,7 @@ When creating new commands, follow the naming conventions in `doc/command-naming
 4. Create a PR to `main` with a changelog summary
 5. After merge: `git tag vX.Y.Z && git push origin vX.Y.Z`
    - GitHub Actions (`.github/workflows/release.yml`) will automatically build binaries and create a GitHub Release
+   - The Homebrew formula (`yucchiy/homebrew-tap`) and Scoop manifest (`yucchiy/scoop-bucket`) are automatically updated by CI (using the `UNICLI_RELEASE_TOKEN` secret)
 
 ### Tests requiring Unity connection
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ brew tap yucchiy/tap
 brew install unicli
 ```
 
+**Scoop (Windows):**
+
+```powershell
+scoop bucket add unicli https://github.com/yucchiy/scoop-bucket
+scoop install unicli
+```
+
 **Manual:** Download the latest binary from the [Releases](https://github.com/yucchiy/UniCli/releases) page and place it in your PATH.
 
 ### Unity Package


### PR DESCRIPTION
## Summary
- Add Scoop support: created `yucchiy/scoop-bucket` repo with `bucket/unicli.json` manifest for v0.14.0
- Update `release.yml` to automatically update both the Scoop manifest (`yucchiy/scoop-bucket`) and Homebrew formula (`yucchiy/homebrew-tap`) when a new version is tagged
- Add Scoop installation instructions to README.md
- Document the automatic package manager updates in CLAUDE.md release notes

## Prerequisites
- `UNICLI_RELEASE_TOKEN` secret must be configured with write access to both `yucchiy/scoop-bucket` and `yucchiy/homebrew-tap`

## Test plan
- [x] Verify YAML syntax of `release.yml` is valid
- [x] Verify `yucchiy/scoop-bucket` contains correct manifest at `bucket/unicli.json`
- [x] Confirm the workflow runs successfully on next tag push
- [x] Test `scoop bucket add unicli https://github.com/yucchiy/scoop-bucket && scoop install unicli` on Windows