### PR TITLE
Remove logging toggle from runtime components

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/UniCliSettings.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/UniCliSettings.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using UniCli.Remote;
 using UniCli.Server.Editor.Handlers;
 using UnityEditor;
 
@@ -11,7 +10,6 @@ namespace UniCli.Server.Editor
     {
         internal const string DisabledModulesConfigKey = "UniCli.disabledModules";
         internal const string EditorLoggingEnabledConfigKey = "UniCli.editor.logging.enabled";
-        internal const string RemoteDiscoveryLogConfigKey = "UniCli.remote.logCommandDiscovery";
 
         HashSet<string> LoadDisabledModules()
         {
@@ -36,7 +34,6 @@ namespace UniCli.Server.Editor
         {
             var value = enabled ? "1" : "0";
             EditorUserSettings.SetConfigValue(EditorLoggingEnabledConfigKey, value);
-            EditorUserSettings.SetConfigValue(RemoteDiscoveryLogConfigKey, value);
 
             ApplyEditorLoggingEnabled(enabled);
         }
@@ -44,19 +41,12 @@ namespace UniCli.Server.Editor
         internal static bool ReadEditorLoggingEnabled()
         {
             var raw = EditorUserSettings.GetConfigValue(EditorLoggingEnabledConfigKey);
-            if (string.IsNullOrEmpty(raw))
-            {
-                // Backward compatibility with the previous remote-only setting key.
-                raw = EditorUserSettings.GetConfigValue(RemoteDiscoveryLogConfigKey);
-            }
-
             return ParseEnabledFlag(raw, defaultValue: true);
         }
 
         internal static void ApplyEditorLoggingEnabled(bool enabled)
         {
             UniCliEditorLog.EnableLogs = enabled;
-            DebugCommandRegistry.EnableLogs = enabled;
         }
 
         internal static bool ParseEnabledFlag(string raw, bool defaultValue)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Runtime/Remote/DebugCommandRegistry.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Runtime/Remote/DebugCommandRegistry.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
-using UnityEngine;
 using UnityEngine.Scripting;
 
 namespace UniCli.Remote
@@ -12,8 +8,6 @@ namespace UniCli.Remote
     [Preserve]
     public sealed class DebugCommandRegistry
     {
-        public static bool EnableLogs { get; set; } = ResolveInitialEnableLogs();
-
         private readonly Dictionary<string, DebugCommand> _commands = new();
         private readonly Dictionary<string, DebugCommandAttribute> _attributes = new();
 
@@ -51,21 +45,16 @@ namespace UniCli.Remote
                     {
                         var instance = (DebugCommand)Activator.CreateInstance(type);
                         if (!_commands.TryAdd(attr.Name, instance))
-                        {
-                            LogWarning($"[UniCli.Remote] Duplicate debug command '{attr.Name}', skipping {type.FullName}");
                             continue;
-                        }
 
                         _attributes[attr.Name] = attr;
                     }
-                    catch (Exception ex)
+                    catch
                     {
-                        LogWarning($"[UniCli.Remote] Failed to create debug command '{attr.Name}' ({type.FullName}): {ex.Message}");
+                        // Silently skip commands that fail to instantiate.
                     }
                 }
             }
-
-            Log($"[UniCli.Remote] Discovered {_commands.Count} debug command(s)");
         }
 
         public bool TryGetCommand(string name, out DebugCommand command)
@@ -85,44 +74,6 @@ namespace UniCli.Remote
                 });
             }
             return infos.ToArray();
-        }
-
-        private static void Log(string message)
-        {
-            if (EnableLogs)
-                UnityEngine.Debug.Log(message);
-        }
-
-        private static void LogWarning(string message)
-        {
-            if (EnableLogs)
-                UnityEngine.Debug.LogWarning(message);
-        }
-
-        private static bool ResolveInitialEnableLogs()
-        {
-#if UNITY_EDITOR
-            var raw = EditorUserSettings.GetConfigValue("UniCli.editor.logging.enabled");
-            if (string.IsNullOrEmpty(raw))
-                raw = EditorUserSettings.GetConfigValue("UniCli.remote.logCommandDiscovery");
-
-            return ParseEnabledFlag(raw, defaultValue: true);
-#else
-            return true;
-#endif
-        }
-
-        private static bool ParseEnabledFlag(string raw, bool defaultValue)
-        {
-            if (string.IsNullOrEmpty(raw))
-                return defaultValue;
-
-            return raw switch
-            {
-                "1" => true,
-                "0" => false,
-                _ => bool.TryParse(raw, out var enabled) ? enabled : defaultValue
-            };
         }
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Runtime/Remote/RuntimeDebugReceiver.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Runtime/Remote/RuntimeDebugReceiver.cs
@@ -48,8 +48,6 @@ namespace UniCli.Remote
             PlayerConnection.instance.Register(RuntimeMessageGuids.CommandRequest, OnCommandRequest);
             PlayerConnection.instance.Register(RuntimeMessageGuids.ListRequest, OnListRequest);
 
-            if (DebugCommandRegistry.EnableLogs)
-                UnityEngine.Debug.Log("[UniCli.Remote] RuntimeDebugReceiver initialized");
         }
 
         private void OnDestroy()


### PR DESCRIPTION
## Summary
- Remove `EnableLogs` static property, `Log`/`LogWarning` helpers, `ResolveInitialEnableLogs`, and `ParseEnabledFlag` from `DebugCommandRegistry` (runtime)
- Remove conditional initialization log from `RuntimeDebugReceiver` (runtime)
- Remove `DebugCommandRegistry.EnableLogs` reference from `UniCliSettings.ApplyEditorLoggingEnabled` (editor)
- Remove unused `RemoteDiscoveryLogConfigKey` constant from `UniCliSettings`

## Motivation
Follow-up to #87. Runtime components cannot access `UniCliSettings` (editor-only), so the PR worked around this with `#if UNITY_EDITOR` blocks and duplicated `ParseEnabledFlag` logic. Instead, simply remove logging from runtime components — warnings are kept unconditional via `Debug.LogWarning` for error visibility, and the informational discovery log is removed entirely.

## Test plan
- [x] Unity compilation passes (`exec Compile`)
- [x] All 39 EditMode tests pass (`exec TestRunner.RunEditMode`)