### PR TITLE
Add UNICLI_PROJECT env var docs to skill files

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -28,6 +28,22 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 7. **When checking console logs**: Use `--logType "Warning,Error"` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `--stackTraceLines 3` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. Do not rely on memorized command lists — the project may have custom commands.
 
+## Project Path
+
+By default, `unicli` looks for a Unity project in the current working directory.
+If the Unity project is in a subdirectory, set the `UNICLI_PROJECT` environment variable:
+
+```bash
+export UNICLI_PROJECT=path/to/unity/project
+unicli exec Compile --json
+```
+
+Or prefix each command:
+
+```bash
+UNICLI_PROJECT=path/to/unity/project unicli exec Compile --json
+```
+
 ## Prerequisites
 
 Before running commands, verify that the CLI is installed and the Editor is reachable:

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -31,6 +31,22 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 7. **When checking console logs**: Use `--logType "Warning,Error"` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `--stackTraceLines 3` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. Do not rely on memorized command lists — the project may have custom commands.
 
+## Project Path
+
+By default, `unicli` looks for a Unity project in the current working directory.
+If the Unity project is in a subdirectory, set the `UNICLI_PROJECT` environment variable:
+
+```bash
+export UNICLI_PROJECT=path/to/unity/project
+unicli exec Compile --json
+```
+
+Or prefix each command:
+
+```bash
+UNICLI_PROJECT=path/to/unity/project unicli exec Compile --json
+```
+
 ## Prerequisites
 
 Before running commands, verify that the CLI is installed and the Editor is reachable:


### PR DESCRIPTION
## Summary
- Add a "Project Path" section to both `.claude-plugin/` and `.agents/` skill SKILL.md files
- Documents the `UNICLI_PROJECT` environment variable for specifying the Unity project path when running `unicli` from outside the project root

## Test plan
- [x] Verify SKILL.md renders correctly in both Claude and Codex skill contexts