### PR TITLE
Release v1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
- Bump UniCli version to `1.1.0` for release

## Updated files
- `src/UniCli.Client/UniCli.Client.csproj`
- `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json`
- `.claude-plugin/marketplace.json`

## Notes
- `.claude-plugin/unicli/skills/unity-development/SKILL.md` is already `1.1.0` and did not require changes.
- Release artifacts will be built by GitHub Actions after pushing tag `v1.1.0`.
