### PR TITLE
fix: downgrade Unity 2022 LTS to 2022.3.62f3

### DIFF
--- a/samples/UniCli.Samples.Unity2022LTS/Packages/packages-lock.json
+++ b/samples/UniCli.Samples.Unity2022LTS/Packages/packages-lock.json
@@ -27,7 +27,7 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.ide.visualstudio": "2.0.22",
-        "com.unity.ide.rider": "3.0.38",
+        "com.unity.ide.rider": "3.0.36",
         "com.unity.ide.vscode": "1.2.5",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.performance.profile-analyzer": "1.2.3",
@@ -36,7 +36,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.38",
+      "version": "3.0.36",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/ProjectVersion.txt
+++ b/samples/UniCli.Samples.Unity2022LTS/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.71f1
-m_EditorVersionWithRevision: 2022.3.71f1 (c9bf13b0b844)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)

--- a/src/UniCli.Unity/Packages/packages-lock.json
+++ b/src/UniCli.Unity/Packages/packages-lock.json
@@ -34,7 +34,7 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.ide.visualstudio": "2.0.22",
-        "com.unity.ide.rider": "3.0.37",
+        "com.unity.ide.rider": "3.0.36",
         "com.unity.ide.vscode": "1.2.5",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.performance.profile-analyzer": "1.2.3",
@@ -43,7 +43,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.37",
+      "version": "3.0.36",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/src/UniCli.Unity/ProjectSettings/ProjectVersion.txt
+++ b/src/UniCli.Unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.67f2
-m_EditorVersionWithRevision: 2022.3.67f2 (6bedba8691df)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)


### PR DESCRIPTION
## Summary
- downgrade the main Unity 2022 LTS project from 2022.3.67f2 to 2022.3.62f3
- downgrade the Unity 2022 LTS sample project from 2022.3.71f1 to 2022.3.62f3
- commit the package lock updates resolved by Unity after opening the projects on 2022.3.62f3

Closes #100

## Testing
- opened the projects in Unity 2022.3.62f3 and confirmed the resulting packages-lock.json updates