### PR TITLE
Improve Unity auto-launch behavior

### DIFF
--- a/src/UniCli.Client.Tests/CommandExecutorTests.cs
+++ b/src/UniCli.Client.Tests/CommandExecutorTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using UniCli.Client;
+
+namespace UniCli.Client.Tests;
+
+public class BuildLaunchStartedMessageTests
+{
+    [Fact]
+    public void IncludesAbsoluteProjectRootAndRetryGuidance()
+    {
+        var result = CommandExecutor.BuildLaunchStartedMessage("src/UniCli.Unity");
+
+        Assert.Contains("Unity Editor was not running, so UniCli started it.", result);
+        Assert.Contains(Path.GetFullPath("src/UniCli.Unity"), result);
+        Assert.Contains("run the command again", result);
+    }
+
+    [Fact]
+    public void AssetsPath_IsNormalizedToProjectRoot()
+    {
+        var result = CommandExecutor.BuildLaunchStartedMessage("src/UniCli.Unity/Assets");
+
+        Assert.Contains(Path.GetFullPath("src/UniCli.Unity"), result);
+        Assert.DoesNotContain(Path.GetFullPath("src/UniCli.Unity/Assets"), result);
+    }
+}

--- a/src/UniCli.Client.Tests/UnityLauncherTests.cs
+++ b/src/UniCli.Client.Tests/UnityLauncherTests.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using UniCli.Client;
+
+namespace UniCli.Client.Tests;
+
+public class CreateStartInfoTests
+{
+    [Fact]
+    public void MacOS_UsesOpenCommandWithAppBundle()
+    {
+        var editorPath = "/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity";
+        var projectRoot = "/tmp/MyProject";
+
+        var startInfo = UnityLauncher.CreateStartInfo(editorPath, projectRoot, isMacOS: true);
+
+        Assert.Equal("open", startInfo.FileName);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.False(startInfo.RedirectStandardOutput);
+        Assert.False(startInfo.RedirectStandardError);
+        Assert.Equal(["-a", "/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app", "--args", "-projectPath", projectRoot], startInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void NonMacOS_UsesDetachedDirectLaunch()
+    {
+        var editorPath = @"C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Unity.exe";
+        var projectRoot = @"C:\work\MyProject";
+
+        var startInfo = UnityLauncher.CreateStartInfo(editorPath, projectRoot, isMacOS: false);
+
+        Assert.Equal(editorPath, startInfo.FileName);
+        Assert.True(startInfo.UseShellExecute);
+        Assert.False(startInfo.RedirectStandardOutput);
+        Assert.False(startInfo.RedirectStandardError);
+        Assert.Equal(["-projectPath", projectRoot], startInfo.ArgumentList);
+    }
+}
+
+public class TryGetMacOSAppBundlePathTests
+{
+    [Fact]
+    public void UnityBinaryInsideAppBundle_ReturnsBundlePath()
+    {
+        var editorPath = "/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/MacOS/Unity";
+
+        var result = UnityLauncher.TryGetMacOSAppBundlePath(editorPath);
+
+        Assert.Equal("/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app", result);
+    }
+
+    [Fact]
+    public void NonBundlePath_ReturnsNull()
+    {
+        var editorPath = "/opt/unity/Editor/Unity";
+
+        var result = UnityLauncher.TryGetMacOSAppBundlePath(editorPath);
+
+        Assert.Null(result);
+    }
+}
+
+public class NormalizeProjectRootTests
+{
+    [Fact]
+    public void RelativeProjectRoot_IsConvertedToAbsolutePath()
+    {
+        var result = UnityLauncher.NormalizeProjectRoot("src/UniCli.Unity");
+
+        Assert.Equal(Path.GetFullPath("src/UniCli.Unity"), result);
+    }
+
+    [Fact]
+    public void AssetsPath_IsTrimmedToProjectRootAndConvertedToAbsolutePath()
+    {
+        var result = UnityLauncher.NormalizeProjectRoot("src/UniCli.Unity/Assets");
+
+        Assert.Equal(Path.GetFullPath("src/UniCli.Unity"), result);
+    }
+}

--- a/src/UniCli.Client/CommandExecutor.cs
+++ b/src/UniCli.Client/CommandExecutor.cs
@@ -11,7 +11,6 @@ namespace UniCli.Client;
 internal static class CommandExecutor
 {
     private const int DefaultMaxRetries = 5;
-    private const int LaunchMaxRetries = 30;
     private const int RetryDelayMs = 1000;
 
     public static async Task<Result<CommandResponse, string>> SendAsync(
@@ -38,8 +37,6 @@ internal static class CommandExecutor
 
         string lastError = "";
         long focusSavedState = 0;
-        var launchAttempted = false;
-
         for (var attempt = 1; attempt <= maxRetries; attempt++)
         {
             using var client = new PipeClient(pipeName);
@@ -49,9 +46,8 @@ internal static class CommandExecutor
             {
                 lastError = connectResult.ErrorValue;
 
-                if (!launchAttempted && !UnityProcessActivator.IsUnityRunning(unityProjectRoot))
+                if (!UnityProcessActivator.IsUnityRunning(unityProjectRoot))
                 {
-                    launchAttempted = true;
                     Console.Error.WriteLine("Unity is not running, launching...");
                     var launchResult = UnityLauncher.Launch(unityProjectRoot);
                     if (launchResult.IsError)
@@ -61,7 +57,9 @@ internal static class CommandExecutor
                             $"Failed to launch Unity Editor: {launchResult.ErrorValue}");
                     }
 
-                    maxRetries = LaunchMaxRetries;
+                    await RestoreFocusAsync(focusSavedState);
+                    return Result<CommandResponse, string>.Error(
+                        BuildLaunchStartedMessage(unityProjectRoot));
                 }
 
                 focusSavedState = await TryFocusOnceAsync(
@@ -113,6 +111,14 @@ internal static class CommandExecutor
     }
 
     private static bool IsRetryableError(string error) => ArgumentParser.IsRetryableError(error);
+
+    internal static string BuildLaunchStartedMessage(string projectRoot)
+    {
+        var normalizedProjectRoot = UnityLauncher.NormalizeProjectRoot(projectRoot);
+        return "Unity Editor was not running, so UniCli started it.\n"
+            + $"  Project: {normalizedProjectRoot}\n"
+            + "  Wait for Unity Editor to finish loading, then run the command again.";
+    }
 
     private static async Task<long> TryFocusOnceAsync(
         bool focusEditor, long savedState, string projectRoot)

--- a/src/UniCli.Client/UnityLauncher.cs
+++ b/src/UniCli.Client/UnityLauncher.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using UniCli.Protocol;
 
 namespace UniCli.Client;
@@ -49,17 +48,25 @@ internal static class UnityLauncher
         }
 
         var normalizedRoot = NormalizeProjectRoot(projectRoot);
+        var startInfo = CreateStartInfo(editorPath, normalizedRoot, OperatingSystem.IsMacOS());
 
-        Process.Start(new ProcessStartInfo
-        {
-            FileName = editorPath,
-            Arguments = $"-projectPath \"{normalizedRoot}\"",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        });
+        using var process = Process.Start(startInfo);
+        if (process == null)
+            return Result<bool, string>.Error("Failed to start Unity Editor process.");
 
         return Result<bool, string>.Success(true);
+    }
+
+    internal static ProcessStartInfo CreateStartInfo(string editorPath, string projectRoot, bool isMacOS)
+    {
+        if (isMacOS)
+        {
+            var appBundlePath = TryGetMacOSAppBundlePath(editorPath);
+            if (appBundlePath != null)
+                return CreateMacOSOpenStartInfo(appBundlePath, projectRoot);
+        }
+
+        return CreateDirectStartInfo(editorPath, projectRoot);
     }
 
     internal static string? ReadEditorVersion(string projectRoot)
@@ -92,11 +99,57 @@ internal static class UnityLauncher
         return null;
     }
 
-    private static string NormalizeProjectRoot(string projectRoot)
+    internal static string? TryGetMacOSAppBundlePath(string editorPath)
+    {
+        var macOsDirectory = Path.GetDirectoryName(editorPath);
+        var contentsDirectory = macOsDirectory != null
+            ? Path.GetDirectoryName(macOsDirectory)
+            : null;
+        var appBundlePath = contentsDirectory != null
+            ? Path.GetDirectoryName(contentsDirectory)
+            : null;
+
+        if (string.IsNullOrEmpty(appBundlePath))
+            return null;
+
+        return string.Equals(Path.GetExtension(appBundlePath), ".app", StringComparison.OrdinalIgnoreCase)
+            ? appBundlePath
+            : null;
+    }
+
+    internal static string NormalizeProjectRoot(string projectRoot)
     {
         var trimmed = projectRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (Path.GetFileName(trimmed) == "Assets")
-            return Path.GetDirectoryName(trimmed) ?? trimmed;
-        return trimmed;
+        var normalized = Path.GetFileName(trimmed) == "Assets"
+            ? Path.GetDirectoryName(trimmed) ?? trimmed
+            : trimmed;
+        return Path.GetFullPath(normalized);
+    }
+
+    private static ProcessStartInfo CreateMacOSOpenStartInfo(string appBundlePath, string projectRoot)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "open",
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-a");
+        startInfo.ArgumentList.Add(appBundlePath);
+        startInfo.ArgumentList.Add("--args");
+        startInfo.ArgumentList.Add("-projectPath");
+        startInfo.ArgumentList.Add(projectRoot);
+        return startInfo;
+    }
+
+    private static ProcessStartInfo CreateDirectStartInfo(string editorPath, string projectRoot)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = editorPath,
+            UseShellExecute = true,
+        };
+        startInfo.ArgumentList.Add("-projectPath");
+        startInfo.ArgumentList.Add(projectRoot);
+        return startInfo;
     }
 }


### PR DESCRIPTION
## Summary
- detach Unity Editor launch from the CLI process and normalize the project path before launch
- stop waiting for the Unity server after auto-launch and tell the user to rerun the command once the editor finishes loading
- add tests for launch configuration, project path normalization, and the auto-launch guidance message

## Testing
- dotnet test src/UniCli.Client.Tests/UniCli.Client.Tests.csproj