### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,8 +14,8 @@ dotnet_naming_rule.private_fields_with_underscore.symbols = private_fields
 dotnet_naming_rule.private_fields_with_underscore.style = underscore_prefix
 dotnet_naming_rule.private_fields_with_underscore.severity = suggestion
 
-dotnet_naming_symbol.private_fields.applicable_kinds = field
-dotnet_naming_symbol.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
 dotnet_naming_style.underscore_prefix.capitalization = camel_case
 dotnet_naming_style.underscore_prefix.required_prefix = _


### PR DESCRIPTION
Rules applied to *.cs files:

Indent size: 4 spaces
Trailing whitespace is trimmed
Private fields must use _camelCase prefix (e.g., _myField)
All non-interface members must declare explicit accessibility modifiers (e.g., private, public)