### PR TITLE
Remove code using an obsolete field in RemoteLinkerProcessor

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Build/RemoteLinkerProcessor.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Build/RemoteLinkerProcessor.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.UnityLinker;
+using UnityEngine;
 
 namespace UniCli.Server.Editor.Build
 {
@@ -16,7 +17,7 @@ namespace UniCli.Server.Editor.Build
             if (!IsRemoteAssemblyIncluded(report))
                 return null;
 
-            var path = Path.Combine(data.inputDirectory, "UniCli.Remote.link.xml");
+            var path = Path.Combine(Application.dataPath, "..", "Temp", "UniCli.Remote.link.xml");
             File.WriteAllText(path, "<linker>\n  <assembly fullname=\"UniCli.Remote\" preserve=\"all\" />\n</linker>\n");
             return path;
         }


### PR DESCRIPTION
Replace `UnityLinkerBuildPipelineData.inputDirectory` with a hardcoded Temp folder because `inputDirectory` is obsolete.

For reference: Unity's official `com.unity.inputsystem` package also generates a link.xml file in the Temp folder in the same way.