### PR TITLE
Fix `Prefab.Instantiate` silently ignoring invalid parent

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Prefab/PrefabInstantiateHandler.cs
@@ -35,7 +35,21 @@ namespace UniCli.Server.Editor.Handlers
                     new PrefabInstantiateResponse());
             }
 
-            var instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            GameObject instance;
+            if (request.parentInstanceId == 0 && string.IsNullOrEmpty(request.parentPath))
+            {
+                instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            }
+            else
+            {
+                var parent = GameObjectResolver.ResolveByIdOrPath(request.parentInstanceId, request.parentPath);
+                if (parent == null)
+                    throw new CommandFailedException(
+                        $"Parent GameObject not found (instanceId={request.parentInstanceId}, path=\"{request.parentPath}\")",
+                        new PrefabInstantiateResponse());
+                instance = PrefabUtility.InstantiatePrefab(prefab, parent.transform) as GameObject;
+            }
+
             if (instance == null)
             {
                 throw new CommandFailedException(
@@ -44,10 +58,6 @@ namespace UniCli.Server.Editor.Handlers
             }
 
             Undo.RegisterCreatedObjectUndo(instance, "Instantiate Prefab");
-
-            var parent = GameObjectResolver.ResolveByIdOrPath(request.parentInstanceId, request.parentPath);
-            if (parent != null)
-                instance.transform.SetParent(parent.transform, true);
 
             return new ValueTask<PrefabInstantiateResponse>(new PrefabInstantiateResponse
             {


### PR DESCRIPTION
## Issue

`Prefab.Instantiate` currently instantiates prefabs successfully even when the specified parent path does not exist. This confuses AI agents, as they may expect the prefab to be instantiated under the specified parent.

## Steps to reproduce:

### 0. Preparation
```bash
UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Save \
'{"path":"Main Camera","assetPath":"Assets/TestPrefab.prefab"}' --json
```

### 1. Valid parent
```bash
UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Instantiate \
'{"assetPath":"Assets/TestPrefab.prefab","parentPath":"Main Camera"}' --json
```
Result: Instantiates under parent "Main Camera" successfully.

### 2. Non-existent parent
```bash
UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Prefab.Instantiate \
'{"assetPath":"Assets/TestPrefab.prefab","parentPath":"NonExistentParent"}' --json
```
Result: Instantiates at root level silently regardless of the non-existent parent path.

## Changes:
- Added validation to check if the specified parent path exists before calling `SetParent`.