### PR TITLE
Fix eval reference conflicts caused by implicit Unity assemblies

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -140,6 +140,9 @@ public static class {className}
 }}";
         }
 
+        /// <summary>
+        /// Collects additional references that should be passed explicitly to eval compilation.
+        /// </summary>
         private static string[] GetAdditionalReferences()
         {
             var seen = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -152,7 +155,8 @@ public static class {className}
                     var loc = asm.Location;
                     if (string.IsNullOrEmpty(loc)) continue;
                     if (!File.Exists(loc)) continue;
-                    if (!seen.Add(asm.GetName().Name)) continue;
+                    if (IsImplicitUnityReference(loc)) continue;
+                    if (!seen.Add(Path.GetFullPath(loc))) continue;
                     refs.Add(loc);
                 }
                 catch
@@ -161,6 +165,28 @@ public static class {className}
                 }
             }
             return refs.ToArray();
+        }
+
+        /// <summary>
+        /// Returns whether the assembly is already provided implicitly by Unity's standard references.
+        /// </summary>
+        /// <remarks>
+        /// Passing Facade/BCL assemblies discovered from the current AppDomain into additionalReferences
+        /// can collide with the references added by UseEngineModules and trigger CS1703.
+        /// </remarks>
+        private static bool IsImplicitUnityReference(string assemblyPath)
+        {
+            var fullPath = Path.GetFullPath(assemblyPath);
+            var unityContentsPath = Path.GetFullPath(EditorApplication.applicationContentsPath);
+            if (!fullPath.StartsWith(unityContentsPath, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var relativePath = fullPath.Substring(unityContentsPath.Length)
+                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            return relativePath.StartsWith(@"MonoBleedingEdge\lib\mono\", StringComparison.OrdinalIgnoreCase)
+                || relativePath.StartsWith(@"NetStandard\ref\", StringComparison.OrdinalIgnoreCase)
+                || relativePath.StartsWith(@"UnityReferenceAssemblies\", StringComparison.OrdinalIgnoreCase);
         }
 
         private static async Task CompileAsync(string sourcePath, string dllPath, CancellationToken cancellationToken)


### PR DESCRIPTION
# Summary

This fixes a problem where `Eval` could hit reference DLL conflicts during dynamic compilation and fail with `CS1703` in specific projects.

The issue was reported in a newly created VRChat World Project, where `unicli eval` failed. Investigation showed that this was not caused by project-specific code, but by `UniCli`'s `EvalHandler` adding too many references during dynamic compilation.

The investigation and fix were done with Codex.

# Root Cause

`EvalHandler` adds loaded assemblies from `AppDomain.CurrentDomain.GetAssemblies()` into `additionalReferences`.

At the same time, `AssemblyBuilder` is configured with `ReferencesOptions.UseEngineModules`, which also brings in Unity's standard reference assemblies.

As a result, Facade / BCL assemblies from `MonoBleedingEdge`, `UnityReferenceAssemblies`, and `NetStandard` could be mixed in twice, which caused `CS1703` in some environments.

# Changes

- Exclude DLLs that Unity already resolves implicitly as standard references from `additionalReferences`
- Change duplicate detection from assembly-name-based to full-path-based
- Add summary comments to `EvalHandler` to document the intent of this behavior

# Impact

- `Eval` is less likely to conflict with Unity's standard references
- Project- and package-specific assemblies are still included in `additionalReferences`
- This should improve `eval` stability in projects with more complex reference layouts, such as VRChat World Projects

# Verification

With `src/UniCli.Unity` open in Unity 2022.3.22f1, I verified the following:

```bash
dotnet build src/UniCli.Client
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll exec Compile --json
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll eval 'return Application.unityVersion;' --json
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll eval 'await Task.Delay(1, cancellationToken); return typeof(UniCli.Server.Editor.Handlers.EvalHandler).FullName;' --json
```

All of the above completed successfully.

# Notes

This issue did not originally reproduce in the repository's bundled `UniCli.Unity` project, but that does not mean the bug was absent there. It means the conflicting reference DLL combination was not present in that specific runtime state.

This change is intended to make `Eval` behavior less dependent on each project's current loaded-reference state.

# 概要

`Eval` 実行時の動的コンパイルで参照 DLL が競合し、特定プロジェクトで `CS1703` が発生する問題を修正します。

背景として、VRChat の World Project を新規作成した環境で `unicli eval` が失敗する事象が発生しました。調査の結果、プロジェクト固有コードの問題ではなく、UniCli の `EvalHandler` が動的コンパイル時に過剰な参照を追加していたことが原因でした。

調査・修正はCodexで行いました。

# 原因

`EvalHandler` は `AppDomain.CurrentDomain.GetAssemblies()` から取得したロード済みアセンブリを `additionalReferences` に追加しています。

一方で `AssemblyBuilder` には `ReferencesOptions.UseEngineModules` も指定されており、Unity が標準参照として自動解決する DLL 群も別途追加されます。

この結果、`MonoBleedingEdge` / `UnityReferenceAssemblies` / `NetStandard` 由来の Facade / BCL が二重に混在し、環境によっては `CS1703` が発生していました。

# 変更内容

- Unity が標準参照として暗黙的に解決する DLL を `additionalReferences` から除外
- 重複判定をアセンブリ名ベースからフルパスベースへ変更
- `EvalHandler` に今回の意図がわかるサマリーコメントを追加

# 影響

- `Eval` が Unity 標準参照と競合しにくくなります
- プロジェクトやパッケージ由来の追加参照は引き続き `additionalReferences` に含まれます
- VRChat World Project のように参照構成が複雑なプロジェクトでも、`eval` の安定性向上が期待できます

# 動作確認

`src/UniCli.Unity` を Unity 2022.3.22f1 で開いた状態で、以下を確認しました。

```bash
dotnet build src/UniCli.Client
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll exec Compile --json
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll eval 'return Application.unityVersion;' --json
UNICLI_PROJECT=src/UniCli.Unity dotnet src/UniCli.Client/bin/Debug/net9.0/unicli.dll eval 'await Task.Delay(1, cancellationToken); return typeof(UniCli.Server.Editor.Handlers.EvalHandler).FullName;' --json
```

いずれも成功を確認しています。

# 補足

このリポジトリ付属の `UniCli.Unity` プロジェクトでは元々再現しませんでしたが、これは不具合が存在しなかったためではなく、衝突する参照 DLL の組み合わせがその場では揃っていなかったためです。

今回の修正は、再現するかどうかを各プロジェクトの参照状態に依存させないためのものです。
