### PR TITLE
feat: add exact name filter to GameObject.Find

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -25,7 +25,7 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 4. **If connection to Unity Editor fails**: Retry 2–3 times, then ask the user to confirm Unity Editor is running with the project open.
 5. **For platform-specific verification**: Use `unicli exec BuildPlayer.Compile --target <platform> --json` to catch platform-specific errors (missing `#if` guards, unsupported APIs, etc.).
 6. **When running tests**: Always use the default `--resultFilter failures` (or `--resultFilter none` for summary-only) to keep output minimal. Only use `--resultFilter all` when you specifically need to inspect individual passed test details. This prevents large test suites from flooding context. Stack traces are omitted by default (`--stackTraceLines 0`); use `--stackTraceLines 3` when you need to diagnose a failure location.
-7. **When checking console logs**: Use `--logType "Warning,Error"` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `--stackTraceLines 3` when debugging errors.
+7. **When checking console logs**: Use `Console.GetLog` with `{"logType":"Warning,Error"}` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `{"logType":"Error","stackTraceLines":3}` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. `--help` includes nested type details when applicable, and `commands --json` provides nested schemas via each command's `requestTypeDetails` and `responseTypeDetails`. Match nested type details by `typeId`; `type` and `typeName` are display labels and may not be unique. Do not rely on memorized command lists — the project may have custom commands.
 
 ## Project Path
@@ -68,10 +68,10 @@ If the package is installed but the connection fails, make sure Unity Editor is 
 
 ## Executing Commands
 
-Run commands with `unicli exec <command>`. Pass parameters as `--key value` flags:
+Run commands with `unicli exec <command>`. Pass parameters as `--key value` flags or raw JSON. Use JSON for arrays and nested values:
 
 ```bash
-unicli exec GameObject.Find --name "Main Camera" --json
+unicli exec GameObject.Find '{"name":"Main Camera"}' --json
 ```
 
 Boolean flags can be passed without a value:

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -28,7 +28,7 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 4. **If connection to Unity Editor fails**: Retry 2–3 times, then ask the user to confirm Unity Editor is running with the project open.
 5. **For platform-specific verification**: Use `unicli exec BuildPlayer.Compile --target <platform> --json` to catch platform-specific errors (missing `#if` guards, unsupported APIs, etc.).
 6. **When running tests**: Always use the default `--resultFilter failures` (or `--resultFilter none` for summary-only) to keep output minimal. Only use `--resultFilter all` when you specifically need to inspect individual passed test details. This prevents large test suites from flooding context. Stack traces are omitted by default (`--stackTraceLines 0`); use `--stackTraceLines 3` when you need to diagnose a failure location.
-7. **When checking console logs**: Use `--logType "Warning,Error"` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `--stackTraceLines 3` when debugging errors.
+7. **When checking console logs**: Use `Console.GetLog` with `{"logType":"Warning,Error"}` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `{"logType":"Error","stackTraceLines":3}` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. Do not rely on memorized command lists — the project may have custom commands.
 
 ## Project Path
@@ -71,10 +71,10 @@ If the package is installed but the connection fails, make sure Unity Editor is 
 
 ## Executing Commands
 
-Run commands with `unicli exec <command>`. Pass parameters as `--key value` flags:
+Run commands with `unicli exec <command>`. Pass parameters as `--key value` flags or raw JSON. Use JSON for arrays and nested values:
 
 ```bash
-unicli exec GameObject.Find --name "Main Camera" --json
+unicli exec GameObject.Find '{"name":"Main Camera"}' --json
 ```
 
 Boolean flags can be passed without a value:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,16 +105,16 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --stac
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json
 
 # Console logs filtered by type (comma-separated)
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog --logType "Warning,Error" --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog '{"logType":"Warning,Error"}' --json
 
 # Console logs with stack traces (first 3 lines)
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog --logType Error --stackTraceLines 3 --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Console.GetLog '{"logType":"Error","stackTraceLines":3}' --json
 
 # Build player
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Development --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Development --options ConnectWithProfiler --json
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --target Android --scenes "Assets/Scenes/SampleScene.unity" --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Build --locationPathName "Builds/Test-Android.apk" --target Android --scenes "Assets/Scenes/SampleScene.unity" --json
 
 # Compile player scripts for a specific build target
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec BuildPlayer.Compile --json

--- a/README.md
+++ b/README.md
@@ -151,15 +151,16 @@ Use `unicli exec <command>` to run commands on the Unity Editor.
 
 ### Parameter syntax
 
-Parameters can be passed as `--key value` flags (recommended) or as a raw JSON string:
+Parameters can be passed as `--key value` flags or as a raw JSON string. For arrays and nested values, JSON is often the clearest option:
 
 ```bash
-# --key value syntax (recommended)
-unicli exec GameObject.Find --name "Main Camera"
-unicli exec TestRunner.RunEditMode --testNameFilter MyTest
+# --key value syntax
+unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Development
 
 # Raw JSON syntax
 unicli exec GameObject.Find '{"name":"Main Camera"}'
+unicli exec GameObject.Find '{"namePattern":"Camera"}'
+unicli exec TestRunner.RunEditMode '{"testNames":["UniCli.Server.Editor.Tests.ResultTests.Success_IsSuccess_ReturnsTrue"]}'
 ```
 
 Boolean flags can be passed without a value:
@@ -197,21 +198,23 @@ unicli exec Compile --timeout 30000
 
 # Build the player
 unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app"
-unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Development --target Android
+unicli exec BuildPlayer.Build --locationPathName "Builds/Test-Android.apk" --options Development --target Android
 
-# Run tests
+# Discover and run tests
+unicli exec TestRunner.List '{"mode":"EditMode"}' --json
 unicli exec TestRunner.RunEditMode
-unicli exec TestRunner.RunEditMode --testNameFilter MyTest --stackTraceLines 3
+unicli exec TestRunner.RunEditMode '{"testNames":["UniCli.Server.Editor.Tests.ResultTests.Success_IsSuccess_ReturnsTrue"],"stackTraceLines":3}'
 unicli exec TestRunner.RunEditMode --resultFilter all
 
 # Find and inspect GameObjects
-unicli exec GameObject.Find --name "Main Camera"
+unicli exec GameObject.Find '{"name":"Main Camera"}'
+unicli exec GameObject.Find '{"namePattern":"Camera"}'
 unicli exec GameObject.GetHierarchy
 unicli exec GameObject.GetComponents --instanceId 1234
 
 # Create and modify GameObjects
 unicli exec GameObject.Create --name "Enemy"
-unicli exec GameObject.SetTransform --path "Enemy" --position 1,2,3 --rotation 0,90,0
+unicli exec GameObject.SetTransform '{"path":"Enemy","position":[1,2,3],"rotation":[0,90,0]}'
 unicli exec GameObject.AddComponent --path "Enemy" --typeName BoxCollider
 
 # Scene operations
@@ -222,7 +225,7 @@ unicli exec Scene.Save --all
 unicli exec Component.SetProperty --componentInstanceId 1234 --propertyPath "m_IsKinematic" --value "true"
 
 # Console logs
-unicli exec Console.GetLog --logType "Warning,Error"
+unicli exec Console.GetLog '{"logType":"Warning,Error"}'
 
 # Show command parameters and usage
 unicli exec GameObject.Find --help
@@ -251,7 +254,7 @@ See [Built-in Commands](#built-in-commands) for the full list of available comma
 Code has full access to Unity APIs (`UnityEngine`, `UnityEditor`) as well as any packages and libraries referenced by the project.
 
 ```bash
-unicli eval '<code>' [--json] [--declarations '<decl>'] [--timeout <ms>]
+unicli eval '<code>' [--json] [--declarations '<decl>'] [--timeout <ms>] [--no-focus]
 ```
 
 | Option | Description |
@@ -259,6 +262,7 @@ unicli eval '<code>' [--json] [--declarations '<decl>'] [--timeout <ms>]
 | `--json` | Output in JSON format |
 | `--declarations` | Additional type declarations (classes, structs, enums) |
 | `--timeout` | Timeout in milliseconds |
+| `--no-focus` | Don't bring Unity Editor to front |
 
 For multi-line code, use shell heredocs:
 
@@ -465,6 +469,7 @@ The following commands are built in. Run `unicli commands` to see this list from
 
 | Command | Description |
 |---|---|
+| `TestRunner.List` | List available tests for EditMode or PlayMode |
 | `TestRunner.RunEditMode` | Run EditMode tests (`resultFilter`: `"failures"` (default), `"all"`, `"none"`) |
 | `TestRunner.RunPlayMode` | Run PlayMode tests (`resultFilter`: `"failures"` (default), `"all"`, `"none"`) |
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1275,12 +1275,13 @@ Duplicate an existing GameObject in the scene
 
 ### GameObject.Find
 
-Find GameObjects by name, tag, layer, or component
+Find GameObjects by exact name, name pattern, tag, layer, or component
 
 **Parameters:**
 
 | Field | Type |
 |---|---|
+| `name` | `string` |
 | `namePattern` | `string` |
 | `tag` | `string` |
 | `layer` | `int` (default: `-1`) |
@@ -1862,9 +1863,6 @@ Get the current play mode state
 | `isPlaying` | `bool` |
 | `isPaused` | `bool` |
 | `isCompiling` | `bool` |
-
----
-
 
 ## PlayerSettings
 
@@ -2894,4 +2892,3 @@ Open an EditorWindow by type name
 | `typeName` | `string` |
 
 ---
-

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/FindGameObjectsHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/GameObject/FindGameObjectsHandler.cs
@@ -12,7 +12,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class FindGameObjectsHandler : CommandHandler<FindGameObjectsRequest, FindGameObjectsResponse>
     {
         public override string CommandName => "GameObject.Find";
-        public override string Description => "Find GameObjects by name, tag, layer, or component";
+        public override string Description => "Find GameObjects by exact name, name pattern, tag, layer, or component";
 
         protected override ValueTask<FindGameObjectsResponse> ExecuteAsync(FindGameObjectsRequest request, CancellationToken cancellationToken)
         {
@@ -97,6 +97,14 @@ namespace UniCli.Server.Editor.Handlers
 
         private static bool MatchesFilter(GameObject go, FindGameObjectsRequest request)
         {
+            if (!string.IsNullOrEmpty(request.name))
+            {
+                if (!go.name.Equals(request.name, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
             if (!string.IsNullOrEmpty(request.namePattern))
             {
                 if (!go.name.Contains(request.namePattern, StringComparison.OrdinalIgnoreCase))
@@ -155,6 +163,7 @@ namespace UniCli.Server.Editor.Handlers
     [Serializable]
     public class FindGameObjectsRequest
     {
+        public string name;
         public string namePattern;
         public string tag;
         public int layer = -1;

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/FindGameObjectsHandlerTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/FindGameObjectsHandlerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UniCli.Protocol;
+using UniCli.Server.Editor.Handlers;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Tests
+{
+    [TestFixture]
+    public class FindGameObjectsHandlerTests
+    {
+        private readonly List<GameObject> _createdObjects = new();
+        private FindGameObjectsHandler _handler;
+        private string _prefix;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _handler = new FindGameObjectsHandler();
+            _prefix = $"FindGameObjectsHandlerTests_{Guid.NewGuid():N}";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (var i = _createdObjects.Count - 1; i >= 0; i--)
+            {
+                if (_createdObjects[i] != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(_createdObjects[i]);
+                }
+            }
+
+            _createdObjects.Clear();
+        }
+
+        [Test]
+        public void ExecuteAsync_NameExactMatch_ReturnsOnlyExactName()
+        {
+            var exactName = CreateName("Target");
+            CreateGameObject(exactName);
+            CreateGameObject($"{exactName}(Clone)");
+
+            var response = ExecuteAsync(new FindGameObjectsRequest
+            {
+                name = exactName
+            }).GetAwaiter().GetResult();
+
+            Assert.AreEqual(1, response.totalFound);
+            Assert.AreEqual(1, response.results.Length);
+            Assert.AreEqual(exactName, response.results[0].name);
+        }
+
+        [Test]
+        public void ExecuteAsync_NameExactMatch_IsCaseSensitive()
+        {
+            var lowerCaseName = CreateName("target");
+            CreateGameObject(lowerCaseName);
+
+            var response = ExecuteAsync(new FindGameObjectsRequest
+            {
+                name = CreateName("TARGET")
+            }).GetAwaiter().GetResult();
+
+            Assert.AreEqual(0, response.totalFound);
+            Assert.AreEqual(0, response.results.Length);
+        }
+
+        [Test]
+        public void ExecuteAsync_NamePattern_KeepsCaseInsensitiveSubstringBehavior()
+        {
+            CreateGameObject(CreateName("AlphaBeta"));
+
+            var response = ExecuteAsync(new FindGameObjectsRequest
+            {
+                namePattern = "betA"
+            }).GetAwaiter().GetResult();
+
+            Assert.AreEqual(1, response.totalFound);
+            Assert.AreEqual(1, response.results.Length);
+        }
+
+        [Test]
+        public void ExecuteAsync_NameAndNamePattern_RequiresBothToMatch()
+        {
+            var exactName = CreateName("AlphaBeta");
+            CreateGameObject(exactName);
+            CreateGameObject(CreateName("AlphaGamma"));
+
+            var response = ExecuteAsync(new FindGameObjectsRequest
+            {
+                name = exactName,
+                namePattern = "Gamma"
+            }).GetAwaiter().GetResult();
+
+            Assert.AreEqual(0, response.totalFound);
+            Assert.AreEqual(0, response.results.Length);
+        }
+
+        private async Task<FindGameObjectsResponse> ExecuteAsync(FindGameObjectsRequest request)
+        {
+            var result = await ((ICommandHandler)_handler).ExecuteAsync(
+                new CommandRequest
+                {
+                    command = "GameObject.Find",
+                    data = JsonUtility.ToJson(request),
+                    format = "json"
+                },
+                CancellationToken.None);
+
+            return (FindGameObjectsResponse)result;
+        }
+
+        private GameObject CreateGameObject(string name)
+        {
+            var gameObject = new GameObject(name);
+            _createdObjects.Add(gameObject);
+            return gameObject;
+        }
+
+        private string CreateName(string suffix) => $"{_prefix}_{suffix}";
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/FindGameObjectsHandlerTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/FindGameObjectsHandlerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8162e9ff0e7c4be6bcb4ff9e5962d48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add an exact `name` filter to `GameObject.Find` while keeping `namePattern` as the existing case-insensitive substring match.

Also update the README, generated command reference, and agent docs to reflect the new request shape, and add EditMode tests for exact match, case sensitivity, and `namePattern` compatibility.