### PR TITLE
fix: remove UseEngineModules to fix CS1703 duplicate assembly errors in play mode

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -169,7 +169,6 @@ public static class {className}
 
             var builder = new AssemblyBuilder(dllPath, sourcePath)
             {
-                referencesOptions = ReferencesOptions.UseEngineModules,
                 additionalReferences = GetAdditionalReferences()
             };
 


### PR DESCRIPTION
## Problem

`unicli eval` fails in Unity play mode with CS1703 errors:

```
error CS1703: Multiple assemblies with equivalent identity have been imported:
'...MonoBleedingEdge/lib/mono/unityjit-win32/Facades/System.Threading.dll' and
'...NetStandard/compat/2.1.0/shims/netstandard/System.Threading.dll'.
Remove one of the duplicate references.
```

This only occurs in play mode, not edit mode.

## Root cause

`CompileAsync` sets both `referencesOptions = ReferencesOptions.UseEngineModules` **and** `additionalReferences = GetAdditionalReferences()`.

`GetAdditionalReferences()` already deduplicates by assembly simple name across all `AppDomain` assemblies. However, in play mode, Unity loads additional MonoBleedingEdge facade DLLs and NetStandard shims that share the same simple names (e.g. `System.Threading`, `System.Collections`, `System.ObjectModel`). These extra assemblies are not present in edit mode, which is why the bug only manifests in play mode.

`UseEngineModules` then adds engine module references that overlap with what `GetAdditionalReferences()` already collected, causing the compiler to receive two DLLs with the same simple name → CS1703.

## Fix

Remove `referencesOptions = ReferencesOptions.UseEngineModules`. Since `GetAdditionalReferences()` collects all loaded `AppDomain` assemblies (which includes all engine modules in both edit and play mode), `UseEngineModules` is redundant and causes the conflict.

## Tested on

- Unity 6000.2.0b7, Windows 11
- Verified `unicli eval` works correctly in both edit mode and play mode after the fix