### PR TITLE
Release v1.3.0

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.2.2"
+  version: "1.3.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.2.2"
+  version: "1.3.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.2.2</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
- Bump version to 1.3.0

## Impact
- `src/UniCli.Client/UniCli.Client.csproj`
- `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json`
- `.claude-plugin/marketplace.json`
- `.claude-plugin/unicli/skills/unity-development/SKILL.md`
- `.agents/skills/unity-development/SKILL.md`

## Changelog (since v1.2.2)

### Features
- Add Linux support for the UniCli CLI (#122)
- Add `PlayMode.Step` command (#128)
- Add exact `name` filter to `GameObject.Find` (#132)

### Bug Fixes
- Fix `Prefab.Instantiate` silently ignoring invalid parent (#124)
- Fix `PlayMode.Enter` behavior when scripts have compilation errors (#125)
- Fix missing Undo registration in `Material.SetColor` and `Material.SetFloat` (#126)
- Fix unsubscribe handling for `compilationFinished` (#127)
- Fix missing Undo registration in `AnimatorController.*` handlers (#130)

### CI / Tooling
- Add lint CI (#120)

## Test
- `dotnet format UniCli.sln --verify-no-changes`
- `dotnet build src/UniCli.Protocol`
- `dotnet publish src/UniCli.Client -o .build`
- `dotnet test src/UniCli.Client.Tests/UniCli.Client.Tests.csproj --no-restore`
  - Passed: 52, Skipped: 6, Failed: 0
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json`
  - errorCount: 0
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode '{"resultFilter":"none"}' --json`
  - Passed: 49, Failed: 0
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode '{"resultFilter":"none"}' --json`
  - Total: 0

## Open items
- None
