### PR TITLE
Fix screenshot capture timing

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
@@ -35,7 +35,7 @@ namespace UniCli.Server.Editor.Handlers
             return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
         }
 
-        protected override ValueTask<ScreenshotCaptureResponse> ExecuteAsync(ScreenshotCaptureRequest request, CancellationToken cancellationToken)
+        protected override async ValueTask<ScreenshotCaptureResponse> ExecuteAsync(ScreenshotCaptureRequest request, CancellationToken cancellationToken)
         {
             if (!EditorApplication.isPlaying)
                 throw new InvalidOperationException("Screenshot.Capture requires Play Mode. Use PlayMode.Enter first.");
@@ -53,17 +53,12 @@ namespace UniCli.Server.Editor.Handlers
 
             int capturedWidth;
             int capturedHeight;
-
             Texture2D tex = null;
             try
             {
-                tex = ScreenCapture.CaptureScreenshotAsTexture(superSize);
-                if (tex == null)
-                    throw new InvalidOperationException("Failed to capture screenshot. Ensure the Game View is visible and rendering.");
-
+                tex = await CaptureScreenshotAsync(superSize, cancellationToken);
                 capturedWidth = tex.width;
                 capturedHeight = tex.height;
-
                 var pngBytes = tex.EncodeToPNG();
                 File.WriteAllBytes(path, pngBytes);
             }
@@ -79,13 +74,64 @@ namespace UniCli.Server.Editor.Handlers
                 throw new InvalidOperationException($"Failed to save screenshot to: {fullPath}");
 
             var fileInfo = new FileInfo(fullPath);
-            return new ValueTask<ScreenshotCaptureResponse>(new ScreenshotCaptureResponse
+            return new ScreenshotCaptureResponse
             {
                 path = fullPath,
                 width = capturedWidth,
                 height = capturedHeight,
                 size = fileInfo.Length
-            });
+            };
+        }
+
+        private static async Task<Texture2D> CaptureScreenshotAsync(int superSize, CancellationToken cancellationToken)
+        {
+            var gameObject = new GameObject("UniCliScreenshotCaptureRunner")
+            {
+                hideFlags = HideFlags.HideAndDontSave
+            };
+            UnityEngine.Object.DontDestroyOnLoad(gameObject);
+
+            var runner = gameObject.AddComponent<ScreenshotCaptureRunner>();
+
+            try
+            {
+                return await runner.CaptureAsync(superSize, cancellationToken);
+            }
+            finally
+            {
+                if (gameObject != null)
+                    UnityEngine.Object.Destroy(gameObject);
+            }
+        }
+
+        private sealed class ScreenshotCaptureRunner : MonoBehaviour
+        {
+            public Task<Texture2D> CaptureAsync(int superSize, CancellationToken cancellationToken)
+            {
+                var tcs = new TaskCompletionSource<Texture2D>();
+                StartCoroutine(CaptureCoroutine(superSize, tcs, cancellationToken));
+                return tcs.Task;
+            }
+
+            private System.Collections.IEnumerator CaptureCoroutine(int superSize, TaskCompletionSource<Texture2D> tcs, CancellationToken cancellationToken)
+            {
+                yield return new WaitForEndOfFrame();
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    tcs.TrySetCanceled(cancellationToken);
+                    yield break;
+                }
+
+                var tex = ScreenCapture.CaptureScreenshotAsTexture(superSize);
+                if (tex != null)
+                {
+                    tcs.TrySetResult(tex);
+                    yield break;
+                }
+
+                tcs.TrySetException(new InvalidOperationException("Failed to capture screenshot. Ensure the Game View is visible and rendering."));
+            }
         }
     }
 


### PR DESCRIPTION
#135

## Summary

- fix `Screenshot.Capture` to capture after `WaitForEndOfFrame`
- keep using `ScreenCapture.CaptureScreenshotAsTexture`
- keep the change limited to the screenshot handler

## Details

`Screenshot.Capture` previously called `ScreenCapture.CaptureScreenshotAsTexture` directly from the handler.

In local verification, that could fail in Play Mode with errors like:

```text
CaptureScreenshot(L:0, B:0, W:1920, H:1080) requested a region that exceeds the active Render Target sized [W:1026, H:938].
CaptureScreenshotAsTexture() failed to generate texture! Was method called before the 'end of frame' state was reached?
```

This change moves the capture call into a temporary `MonoBehaviour` coroutine and waits for `WaitForEndOfFrame` before calling `ScreenCapture.CaptureScreenshotAsTexture`.

## Verification

- [x] `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json`
- [x] `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json`
- [x] `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json` succeeds in Play Mode

## Environment

- UniCli client version: `1.3.0`
- UniCli server version: `1.3.0`
- Unity version: `2022.3.62f3`
- OS: `Windows`