### PR TITLE
test: add EditorLogManager ordering tests

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/EditorLogManager.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/EditorLogManager.cs
@@ -21,7 +21,7 @@ namespace UniCli.Server.Editor
         public int displayedCount;
     }
 
-    public sealed class EditorLogManager
+    public sealed class EditorLogManager : IDisposable
     {
         private readonly object _lock = new();
         private readonly Queue<LogEntry> _logBuffer = new();
@@ -123,6 +123,11 @@ namespace UniCli.Server.Editor
             {
                 _logBuffer.Clear();
             }
+        }
+
+        public void Dispose()
+        {
+            Application.logMessageReceivedThreaded -= OnLogMessageReceived;
         }
     }
 }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Tests
+{
+    [TestFixture]
+    public class EditorLogManagerTests
+    {
+        private EditorLogManager _manager;
+        private string _prefix;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _manager = new EditorLogManager();
+            _prefix = $"EditorLogManagerTests_{Guid.NewGuid():N}";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _manager.ClearLogs();
+        }
+
+        [Test]
+        public void GetLogs_ReturnsLogsInChronologicalOrder()
+        {
+            Debug.Log($"{_prefix}_1");
+            Debug.Log($"{_prefix}_2");
+            Debug.Log($"{_prefix}_3");
+
+            var logs = _manager.GetLogs("All", _prefix, 0);
+
+            Assert.AreEqual(3, logs.Length);
+            Assert.AreEqual($"{_prefix}_1", logs[0].message);
+            Assert.AreEqual($"{_prefix}_2", logs[1].message);
+            Assert.AreEqual($"{_prefix}_3", logs[2].message);
+        }
+
+        [Test]
+        public void GetLogs_WithMaxCount_ReturnsNewestEntriesInChronologicalOrder()
+        {
+            Debug.Log($"{_prefix}_1");
+            Debug.Log($"{_prefix}_2");
+            Debug.Log($"{_prefix}_3");
+            Debug.Log($"{_prefix}_4");
+
+            var logs = _manager.GetLogs("All", _prefix, 2);
+
+            Assert.AreEqual(2, logs.Length);
+            Assert.AreEqual($"{_prefix}_3", logs[0].message);
+            Assert.AreEqual($"{_prefix}_4", logs[1].message);
+        }
+
+        [Test]
+        public void GetLogs_WithLogTypeFilter_PreservesChronologicalOrder()
+        {
+            Debug.Log($"{_prefix}_Log1");
+            Debug.LogWarning($"{_prefix}_Warn1");
+            Debug.Log($"{_prefix}_Log2");
+            Debug.LogWarning($"{_prefix}_Warn2");
+            Debug.Log($"{_prefix}_Log3");
+
+            var logs = _manager.GetLogs("Warning", _prefix, 0);
+
+            Assert.AreEqual(2, logs.Length);
+            Assert.AreEqual($"{_prefix}_Warn1", logs[0].message);
+            Assert.AreEqual($"{_prefix}_Warn2", logs[1].message);
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs
@@ -21,6 +21,8 @@ namespace UniCli.Server.Editor.Tests
         public void TearDown()
         {
             _manager.ClearLogs();
+            _manager.Dispose();
+            _manager = null;
         }
 
         [Test]

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EditorLogManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e5501099c29199468636a87e740e270
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add tests to verify `EditorLogManager.GetLogs` returns logs in chronological order.