### PR TITLE
fix: exclude Unity editor assemblies from eval additional references to prevent CS1703

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -142,7 +142,20 @@ public static class {className}
 
         private static string[] GetAdditionalReferences()
         {
+            var editorContentsPath = EditorApplication.applicationContentsPath;
             var seen = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (asm.IsDynamic) continue;
+                try
+                {
+                    var loc = asm.Location;
+                    if (!string.IsNullOrEmpty(loc) && loc.StartsWith(editorContentsPath, StringComparison.Ordinal))
+                        seen.Add(asm.GetName().Name);
+                }
+                catch { }
+            }
+
             var refs = new System.Collections.Generic.List<string>();
             foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
             {


### PR DESCRIPTION
## 概要
- `unicli eval` が特定環境でCS1703(duplicate assembly identity)により動作しない問題を修正
- `GetAdditionalReferences()` に1st pass を追加し、Unity エディタディレクトリ配下のアセンブリ名を `seen` HashSet に先行登録することで、`UseEngineModules` が暗黙的に追加する参照との重複を防止

## 詳細
`EvalHandler.CompileAsync()` は `ReferencesOptions.UseEngineModules` と `additionalReferences` の両方でアセンブリ参照を構成しています。特定環境で `System.Threading.dll` 等が `MonoBleedingEdge/Facades/` と `NetStandard/compat/shims/` の両パスから `AppDomain` にロードされており、`additionalReferences` 経由で追加されたものが `UseEngineModules` の暗黙参照と重複し CS1703 が発生していました。

既存の `seen` HashSet による重複排除は `additionalReferences` 内部のみに有効で、`UseEngineModules` が追加する参照との cross-source な重複は検出できていませんでした。

## 再現手順
1. [System.Diagnostics.DiagnosticSource.zip](https://github.com/user-attachments/files/26856322/System.Diagnostics.DiagnosticSource.zip)のフォルダを `Assets/` 以下に配置
2. `unicli eval 'return "Hello";'` を実行すると下記のエラーが発生（手元の環境 Unity 6000.2.13f1 で検証）

```
error CS1703: Multiple assemblies with equivalent identity have been imported: '/Applications/Unity/Hub/Editor/6000.2.13f1/Unity.app/Contents/MonoBleedingEdge/lib/mono/unityjit-macos/Facades/System.Threading.dll' and '/Applications/Unity/Hub/Editor/6000.2.13f1/Unity.app/Contents/NetStandard/compat/2.1.0/shims/netstandard/System.Threading.dll'. Remove one of the duplicate references.
```


## 修正
`EditorApplication.applicationContentsPath` 配下のアセンブリ名を事前に `seen` に登録し、`additionalReferences` から除外します。

## テスト
  - [x] `unicli exec Compile --json` — Unity コンパイル成功 (エラー 0)
  - [x] `unicli eval 'return "Hello";' --json` — 最小 eval 成功
  - [x] `unicli eval 'return Application.unityVersion;' --json` — Unity API 参照 eval 成功
  - [x] `unicli exec TestRunner.RunEditMode --json` — EditMode テスト全 49 件パス