### PR TITLE
Fix implicit Unity eval references on Unity 6

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs
@@ -176,17 +176,35 @@ public static class {className}
         /// </remarks>
         private static bool IsImplicitUnityReference(string assemblyPath)
         {
-            var fullPath = Path.GetFullPath(assemblyPath);
-            var unityContentsPath = Path.GetFullPath(EditorApplication.applicationContentsPath);
-            if (!fullPath.StartsWith(unityContentsPath, StringComparison.OrdinalIgnoreCase))
+            return IsImplicitUnityReference(assemblyPath, EditorApplication.applicationContentsPath);
+        }
+
+        internal static bool IsImplicitUnityReference(string assemblyPath, string unityContentsPath)
+        {
+            var normalizedAssemblyPath = NormalizePath(Path.GetFullPath(assemblyPath));
+            var normalizedUnityContentsPath = NormalizePath(Path.GetFullPath(unityContentsPath)).TrimEnd('/');
+            var unityPathPrefix = normalizedUnityContentsPath + "/";
+
+            if (!normalizedAssemblyPath.StartsWith(unityPathPrefix, StringComparison.OrdinalIgnoreCase))
                 return false;
 
-            var relativePath = fullPath.Substring(unityContentsPath.Length)
-                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var relativePath = normalizedAssemblyPath.Substring(unityPathPrefix.Length);
+            return IsImplicitUnityReferenceRelativePath(relativePath);
+        }
 
-            return relativePath.StartsWith(@"MonoBleedingEdge\lib\mono\", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith(@"NetStandard\ref\", StringComparison.OrdinalIgnoreCase)
-                || relativePath.StartsWith(@"UnityReferenceAssemblies\", StringComparison.OrdinalIgnoreCase);
+        internal static bool IsImplicitUnityReferenceRelativePath(string relativePath)
+        {
+            var normalizedRelativePath = NormalizePath(relativePath).TrimStart('/');
+
+            return normalizedRelativePath.StartsWith("MonoBleedingEdge/lib/mono/", StringComparison.OrdinalIgnoreCase)
+                || normalizedRelativePath.StartsWith("NetStandard/ref/", StringComparison.OrdinalIgnoreCase)
+                || normalizedRelativePath.StartsWith("NetStandard/compat/", StringComparison.OrdinalIgnoreCase)
+                || normalizedRelativePath.StartsWith("UnityReferenceAssemblies/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/');
         }
 
         private static async Task CompileAsync(string sourcePath, string dllPath, CancellationToken cancellationToken)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EvalHandlerTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EvalHandlerTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using UniCli.Server.Editor.Handlers;
+
+namespace UniCli.Server.Editor.Tests
+{
+    [TestFixture]
+    public class EvalHandlerTests
+    {
+        [TestCase("MonoBleedingEdge/lib/mono/unityjit-macos/Facades/System.Threading.dll")]
+        [TestCase(@"MonoBleedingEdge\lib\mono\unityjit-macos\Facades\System.Threading.dll")]
+        [TestCase("NetStandard/ref/2.1.0/System.Runtime.dll")]
+        [TestCase(@"NetStandard\compat\2.1.0\shims\netstandard\System.Threading.dll")]
+        [TestCase("UnityReferenceAssemblies/SomeAssembly.dll")]
+        public void IsImplicitUnityReferenceRelativePath_ImplicitReference_ReturnsTrue(string relativePath)
+        {
+            Assert.That(EvalHandler.IsImplicitUnityReferenceRelativePath(relativePath), Is.True);
+        }
+
+        [TestCase("Managed/UnityEngine.CoreModule.dll")]
+        [TestCase("Library/ScriptAssemblies/MyProject.dll")]
+        public void IsImplicitUnityReferenceRelativePath_NonImplicitReference_ReturnsFalse(string relativePath)
+        {
+            Assert.That(EvalHandler.IsImplicitUnityReferenceRelativePath(relativePath), Is.False);
+        }
+
+        [Test]
+        public void IsImplicitUnityReference_Unity6CompatShimPath_ReturnsTrue()
+        {
+            const string unityContentsPath = "/Applications/Unity/Hub/Editor/6000.2.13f1/Unity.app/Contents";
+            const string assemblyPath = "/Applications/Unity/Hub/Editor/6000.2.13f1/Unity.app/Contents/NetStandard/compat/2.1.0/shims/netstandard/System.Threading.dll";
+
+            Assert.That(EvalHandler.IsImplicitUnityReference(assemblyPath, unityContentsPath), Is.True);
+        }
+
+        [Test]
+        public void IsImplicitUnityReference_PathOutsideUnityContents_ReturnsFalse()
+        {
+            const string unityContentsPath = "/Applications/Unity/Hub/Editor/6000.2.13f1/Unity.app/Contents";
+            const string assemblyPath = "/tmp/System.Threading.dll";
+
+            Assert.That(EvalHandler.IsImplicitUnityReference(assemblyPath, unityContentsPath), Is.False);
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EvalHandlerTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/EvalHandlerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e15807d14dd2b46aaa05775cc5b64f26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Filter implicit Unity framework references before passing `additionalReferences` to eval compilation.
- Normalize path separators and treat `NetStandard/compat` as implicit so Unity 6 does not import duplicate `System.Threading.dll`.
- Add regression tests for Unity implicit reference path detection.

## Impact
- Affects only `Eval` compilation reference collection in `UniCli.Server.Editor`.
- Prevents `CS1703` duplicate assembly import errors on Unity 6 when evaluating code.
- No public API changes.

## Test
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/Editor/Handlers/EvalHandler.cs" --json` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/Tests/Editor/EvalHandlerTests.cs" --json` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `61 passed`, `0 failed`
- `UNICLI_PROJECT=samples/UniCli.Samples.Unity6LTS ./.build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`
- `UNICLI_PROJECT=samples/UniCli.Samples.Unity6LTS ./.build/unicli eval 'return 1 + 2;' --json` → `result: 3`

## Open items
- Live verification was on `6000.0.62f1` via `samples/UniCli.Samples.Unity6LTS`.
- The reported `6000.2.13f1` `NetStandard/compat/.../System.Threading.dll` path is covered by the added regression test, but not yet re-verified on that exact editor build locally.
