### PR TITLE
Release v1.3.2

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.3.1"
+  version: "1.3.2"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.3.1"
+  version: "1.3.2"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
- Bump version to `1.3.2`.
- Prepare the patch release for fixes merged after `v1.3.1`, mainly the Unity 6 `Eval` duplicate-reference fix (`#142`).
- Include supporting test coverage for `RemoteInvokeResponse.ToJson` escaping (`#137`).

## Impact
- Update release-managed version identifiers in the following files:
  - `src/UniCli.Client/UniCli.Client.csproj`
  - `src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json`
  - `.claude-plugin/marketplace.json`
  - `.claude-plugin/unicli/skills/unity-development/SKILL.md`
  - `.agents/skills/unity-development/SKILL.md`
- No public API or data format changes beyond the version bump.
- After merge and tag push, the existing release workflow will publish GitHub release assets and update Homebrew/Scoop manifests.

## Test
- `dotnet format UniCli.slnx --verify-no-changes` → success
- `dotnet test UniCli.slnx` → Passed: 52, Skipped: 6, Failed: 0
- `dotnet publish src/UniCli.Client -o .build` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/package.json" --json` → refreshed: true
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli check` → client/server both `1.3.2`
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec Compile --json` → errorCount: 0, warningCount: 6
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → Passed: 61, Failed: 0
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec TestRunner.RunPlayMode --resultFilter none --json` → Total: 0
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli eval 'return 1 + 2;' --json` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec PlayMode.Enter --json` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec Screenshot.Capture '{"path":"/tmp/unicli-release-smoke-1.3.2.png"}' --json` → success
- `UNICLI_PROJECT=src/UniCli.Unity ./.build/unicli exec PlayMode.Exit --json` → success
- `UNICLI_PROJECT=samples/UniCli.Samples.Unity6LTS ./.build/unicli exec Compile --json` → errorCount: 0, warningCount: 8
- `UNICLI_PROJECT=samples/UniCli.Samples.Unity6LTS ./.build/unicli eval 'return 1 + 2;' --json` → success

## Open items
- Existing nullable/obsolete Unity warnings remain in `Result.cs`, `RemoteLinkerProcessor.cs`, `EvalHandler.cs`, and `PrefabGetStatusHandler.cs`; this release does not change them.
