### PR TITLE
Release v1.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.3.2"
+  version: "1.3.3"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
### Summary

Prepares the `v1.3.3` patch release.

This release includes the Unity `.meta` GUID fix merged in #144 and bumps the CLI, Unity package, and Claude plugin metadata versions from `1.3.2` to `1.3.3`.

### Impact

- Updates the CLI package version to `1.3.3`.
- Updates `com.yucchiy.unicli-server` package metadata to `1.3.3`.
- Updates Claude plugin marketplace and skill metadata to `1.3.3`.
- No additional runtime or API changes are included in this release PR.

### Tests

- `dotnet build src/UniCli.Protocol` passed with existing nullable warnings.
- `dotnet publish src/UniCli.Client -o .build` passed with existing nullable / AOT warnings.
- `git diff --check` passed.

### Unresolved

- After this PR is merged, create and push the release tag: `git tag v1.3.3 && git push origin v1.3.3`.
