### PR TITLE
Add MemorySnapshot analysis commands

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -162,6 +162,34 @@ unicli exec Remote.Invoke '{"command":"Debug.GetPlayerPref","data":"{\"key\":\"H
 
 Built-in debug commands: `Debug.SystemInfo`, `Debug.Stats`, `Debug.GetLogs`, `Debug.GetHierarchy`, `Debug.FindGameObjects`, `Debug.GetScenes`, `Debug.GetPlayerPref`
 
+**Investigate a memory leak:**
+
+`MemorySnapshot.*` commands are available when the project has `com.unity.memoryprofiler`. Captures can come from `MemorySnapshot.Capture`, `Profiler.TakeSnapshot`, or the Memory Profiler window; commands read `.snap` paths or named loaded snapshots and keep heavy snapshot data out of the CLI response.
+
+```bash
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/before.snap"}' --json
+# Reproduce the suspected leak in Play Mode or a connected player.
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/after.snap"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"before"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"native","minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","typeFilter":"Texture2D","limit":20}' --json
+unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":20}' --json
+unicli exec MemorySnapshot.Analyze '{"snapshot":"after","baseSnapshot":"before","limit":10}' --json
+```
+
+Useful MemorySnapshot commands:
+
+- `MemorySnapshot.Capture` — capture a `.snap` file; optional `flags` are `Unity.Profiling.Memory.CaptureFlags` names.
+- `MemorySnapshot.List` / `MemorySnapshot.Load` — list files, then pin a snapshot under a stable `name`/`id`.
+- `MemorySnapshot.Status` / `MemorySnapshot.Unload` — inspect loaded/cached analyses, release one by id/name, or clear all cached entries.
+- `MemorySnapshot.Summary` — category totals and metadata; use `snapshot` or `path`, omitted `path` uses the latest `MemoryCaptures/*.snap`.
+- `MemorySnapshot.AllOfMemory` — Memory Profiler All Of Memory style report; default is bounded type sections, use `limit`, `scope`, `typeFilter`, `nameFilter`, `minSize`, `minSizeDelta`, and `includeNativeObjects` to control output size.
+- `MemorySnapshot.TopObjects` — largest native objects or native/managed type totals; use `scope:"managed"` for managed type aggregation.
+- `MemorySnapshot.Diff` — native/managed type deltas; use `baseSnapshot`/`targetSnapshot` or paths, omitted paths use latest and second latest snapshots.
+- `MemorySnapshot.Analyze` — compact one-shot report combining summary, top types/objects, and optional diff.
+
 ## Custom Command Handlers
 
 The server auto-discovers all `ICommandHandler` implementations via `TypeCache`, so no manual registration is required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,30 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameT
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"gcThresholdBytes":1024}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Profiler.FindSpikes '{"frameTimeThresholdMs":16.6,"gcThresholdBytes":1024,"limit":5}' --json
 
+# Memory snapshot analysis (requires com.unity.memoryprofiler; capture with MemorySnapshot.Capture, Profiler.TakeSnapshot, or the Memory Profiler window)
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Capture --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/before.snap","flags":["ManagedObjects","NativeObjects","NativeAllocations"]}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.List --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"before"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Status --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary '{"path":"MemoryCaptures/my_snapshot.snap"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary '{"snapshot":"after"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","scope":"managed","typeFilter":"System.","limit":20}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","scope":"native","includeNativeObjects":true,"typeFilter":"Texture2D","nameFilter":"atlas","limit":20}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.TopObjects '{"path":"MemoryCaptures/my_snapshot.snap","groupByType":true}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":20}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.TopObjects '{"path":"MemoryCaptures/my_snapshot.snap","typeFilter":"Texture2D","limit":20}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Diff --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Diff '{"basePath":"MemoryCaptures/before.snap","targetPath":"MemoryCaptures/after.snap"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"managed","minSizeDelta":1048576}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Diff '{"scope":"managed","minSizeDelta":1048576}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Analyze '{"snapshot":"after","baseSnapshot":"before","limit":10}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Unload '{"snapshot":"before"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Unload --json
+
 # Recorder operations (requires Play Mode and com.unity.recorder package)
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"path":"Recordings/test.mp4"}' --json

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ unicli exec Component.SetProperty --componentInstanceId 1234 --propertyPath "m_I
 # Console logs
 unicli exec Console.GetLog '{"logType":"Warning,Error"}'
 
+# Memory snapshot leak check (requires com.unity.memoryprofiler)
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/before.snap"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"before"}' --json
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/after.snap"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"native","minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":10}' --json
+unicli exec MemorySnapshot.Analyze '{"snapshot":"after","baseSnapshot":"before","limit":10}' --json
+
 # Show command parameters and usage
 unicli exec GameObject.Find --help
 ```
@@ -631,6 +641,23 @@ The following commands are built in. Run `unicli commands` to see this list from
 | `Profiler.AnalyzeFrames` | Analyze recorded frames and return aggregate statistics |
 | `Profiler.FindSpikes` | Find frames exceeding frame time or GC allocation thresholds |
 
+### Optional: Memory Profiler
+
+Requires Unity Memory Profiler (`com.unity.memoryprofiler`). Use `MemorySnapshot.Capture`, `Profiler.TakeSnapshot`, or the Memory Profiler window to capture `.snap` files.
+
+| Command | Description |
+|---|---|
+| `MemorySnapshot.Capture` | Capture a `.snap` file with configurable `Unity.Profiling.Memory.CaptureFlags` |
+| `MemorySnapshot.List` | List memory snapshot (.snap) files |
+| `MemorySnapshot.Load` | Analyze and pin a snapshot under a `name`/`id` for later commands |
+| `MemorySnapshot.Summary` | Summarize category totals and metadata; use `snapshot` or `path`, omitted `path` uses the latest `MemoryCaptures/*.snap` |
+| `MemorySnapshot.AllOfMemory` | Show a Memory Profiler All Of Memory style report with `limit`, `scope`, `typeFilter`, `nameFilter`, `minSize`, `minSizeDelta`, and `include*` filters |
+| `MemorySnapshot.TopObjects` | List largest retained native objects or native/managed type totals; use `snapshot` or `path` |
+| `MemorySnapshot.Diff` | Compare native or managed type deltas; use `baseSnapshot`/`targetSnapshot` or paths, omitted paths use latest and second latest captures |
+| `MemorySnapshot.Analyze` | Produce a compact summary/top/diff report for leak investigation |
+| `MemorySnapshot.Status` | Show loaded/cached snapshot analyses with id/name/pinned state |
+| `MemorySnapshot.Unload` | Release one loaded snapshot by `snapshot` id/name, or clear cached analysis results |
+
 ### Screenshot / Recorder
 
 | Command | Description |
@@ -700,6 +727,7 @@ The following modules are available:
 | Animation | Animator and AnimatorController operations |
 | Remote | Remote debug and Connection operations |
 | Recorder | Video recording operations (requires `com.unity.recorder`) |
+| MemoryProfiler | Memory snapshot analysis operations (requires `com.unity.memoryprofiler`) |
 | Search | Unity Search API operations |
 | NuGet | NuGet package management (requires NuGetForUnity) |
 | BuildMagic | BuildMagic build scheme operations (requires `jp.co.cyberagent.buildmagic`) |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/AssemblyInfo.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UniCli.Server.Editor.NuGetForUnity")]
 [assembly: InternalsVisibleTo("UniCli.Server.Editor.BuildMagic")]
 [assembly: InternalsVisibleTo("UniCli.Server.Editor.Search")]
+[assembly: InternalsVisibleTo("UniCli.Server.Editor.MemorySnapshot")]
 
 [assembly: GenerateCommands("UnityEditor.PlayerSettings", "PlayerSettings")]
 [assembly: GenerateCommands("UnityEditor.EditorSettings", "EditorSettings")]

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffa04d380e22640768cbaa61b3e91dd5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AssemblyInfo.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+#if UNICLI_MEMORY_PROFILER
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniCli.Server.Editor.MemorySnapshot.Tests")]
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AssemblyInfo.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 209763cda66994463aac25850d4e4c99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/ISnapshotAnalyzer.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/ISnapshotAnalyzer.cs
@@ -1,0 +1,10 @@
+#if UNICLI_MEMORY_PROFILER
+namespace UniCli.Server.Editor.Handlers
+{
+    internal interface ISnapshotAnalyzer
+    {
+        bool IsAvailable(out string unavailableReason);
+        SnapshotAnalysis Analyze(string snapshotPath);
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/ISnapshotAnalyzer.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/ISnapshotAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 187acc879b35946f4bfb214b4b602840
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerPackageAnalyzer.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerPackageAnalyzer.cs
@@ -1,0 +1,49 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Reflection;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal sealed class MemoryProfilerPackageAnalyzer : ISnapshotAnalyzer
+    {
+        public bool IsAvailable(out string unavailableReason)
+        {
+            return MemoryProfilerReflection.TryGet(out _, out unavailableReason);
+        }
+
+        public SnapshotAnalysis Analyze(string snapshotPath)
+        {
+            if (!MemoryProfilerReflection.TryGet(out var reflection, out var unavailableReason))
+                throw new CommandFailedException(unavailableReason, null);
+
+            object reader = null;
+            object snapshot = null;
+
+            try
+            {
+                reader = reflection.CreateFileReader();
+                var openResult = reflection.OpenFileReader(reader, snapshotPath);
+                if (!string.Equals(openResult, "Success", StringComparison.Ordinal))
+                    throw new CommandFailedException($"Failed to open snapshot '{snapshotPath}': {openResult}", null);
+
+                snapshot = reflection.CreateCachedSnapshot(reader);
+                reader = null;
+
+                reflection.CrawlManagedData(snapshot);
+                return reflection.ExtractAnalysis(snapshot, snapshotPath);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw new CommandFailedException(ex.InnerException.Message, null);
+            }
+            finally
+            {
+                if (snapshot != null)
+                    reflection.DisposeCachedSnapshot(snapshot);
+                else if (reader != null)
+                    reflection.CloseFileReader(reader);
+            }
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerPackageAnalyzer.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerPackageAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4b0a3ee644b041eb9b2663773a4f4b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs
@@ -1,0 +1,616 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal sealed class MemoryProfilerReflection
+    {
+        private const BindingFlags InstanceMembers =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        private const BindingFlags StaticMembers =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+        private static MemoryProfilerReflection _cached;
+        private static string _cachedUnavailableReason;
+
+        private readonly ConstructorInfo _fileReaderCtor;
+        private readonly ConstructorInfo _cachedSnapshotCtor;
+        private readonly ConstructorInfo _summaryBuilderCtor;
+
+        private readonly MethodInfo _fileReaderOpen;
+        private readonly MethodInfo _fileReaderClose;
+        private readonly MethodInfo _cachedSnapshotDispose;
+        private readonly MethodInfo _managedDataCrawlerCrawl;
+        private readonly MethodInfo _summaryBuild;
+
+        private readonly PropertyInfo _snapshotMetaData;
+        private readonly PropertyInfo _snapshotTimeStamp;
+        private readonly PropertyInfo _snapshotHasSystemMemoryResidentPages;
+        private readonly PropertyInfo _snapshotCrawledData;
+        private readonly FieldInfo _snapshotNativeObjects;
+        private readonly FieldInfo _snapshotNativeTypes;
+        private readonly FieldInfo _snapshotTypeDescriptions;
+
+        private readonly FieldInfo _nativeObjectsCount;
+        private readonly FieldInfo _nativeObjectsNames;
+        private readonly FieldInfo _nativeObjectsSizes;
+        private readonly FieldInfo _nativeObjectsTypeIndices;
+        private readonly FieldInfo _nativeObjectsInstanceIds;
+
+        private readonly FieldInfo _nativeTypesNames;
+        private readonly FieldInfo _typeDescriptionsNames;
+
+        private readonly FieldInfo _managedDataManagedObjects;
+        private readonly FieldInfo _managedObjectTypeDescription;
+        private readonly FieldInfo _managedObjectSize;
+
+        private readonly FieldInfo _metadataPlatform;
+        private readonly FieldInfo _metadataUnityVersion;
+        private readonly FieldInfo _metadataIsEditorCapture;
+        private readonly FieldInfo _metadataCaptureFlags;
+
+        private readonly PropertyInfo _summaryRows;
+        private readonly PropertyInfo _summaryRowName;
+        private readonly PropertyInfo _summaryRowBaseSize;
+        private readonly PropertyInfo _summaryRowResidentSizeUnavailable;
+        private readonly FieldInfo _memorySizeCommitted;
+        private readonly FieldInfo _memorySizeResident;
+
+        private static readonly Dictionary<Type, DynamicArrayAccessor> DynamicArrayAccessors =
+            new Dictionary<Type, DynamicArrayAccessor>();
+        private static readonly Dictionary<Type, DynamicArrayStructFieldAccessor> DynamicArrayStructFieldAccessors =
+            new Dictionary<Type, DynamicArrayStructFieldAccessor>();
+
+        private MemoryProfilerReflection(Assembly assembly)
+        {
+            var fileReaderType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.Format.QueriedSnapshot.FileReader");
+            var cachedSnapshotType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.CachedSnapshot");
+            var managedDataCrawlerType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.ManagedDataCrawler");
+            var summaryBuilderType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.UI.AllMemorySummaryModelBuilder");
+            var summaryModelType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.UI.MemorySummaryModel");
+            var memorySizeType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.MemorySize");
+            var managedDataType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.ManagedData");
+            var managedObjectInfoType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.ManagedObjectInfo");
+
+            var nativeObjectsType = GetRequiredNestedType(cachedSnapshotType, "NativeObjectEntriesCache");
+            var nativeTypesType = GetRequiredNestedType(cachedSnapshotType, "NativeTypeEntriesCache");
+            var typeDescriptionsType = GetRequiredNestedType(cachedSnapshotType, "TypeDescriptionEntriesCache");
+            var summaryRowType = GetRequiredNestedType(summaryModelType, "Row");
+
+            _fileReaderCtor = GetRequiredConstructor(fileReaderType, Type.EmptyTypes);
+            _cachedSnapshotCtor = GetRequiredConstructor(cachedSnapshotType, new[] { fileReaderType.GetInterface("IFileReader") ?? GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.Format.QueriedSnapshot.IFileReader") });
+            _summaryBuilderCtor = GetRequiredConstructor(summaryBuilderType, new[] { cachedSnapshotType, cachedSnapshotType });
+
+            _fileReaderOpen = GetRequiredMethod(fileReaderType, "Open", new[] { typeof(string) });
+            _fileReaderClose = GetRequiredMethod(fileReaderType, "Close", Type.EmptyTypes);
+            _cachedSnapshotDispose = GetRequiredMethod(cachedSnapshotType, "Dispose", Type.EmptyTypes);
+            _managedDataCrawlerCrawl = GetRequiredMethod(managedDataCrawlerType, "Crawl", new[] { cachedSnapshotType });
+            _summaryBuild = GetRequiredMethod(summaryBuilderType, "Build", Type.EmptyTypes);
+
+            _snapshotMetaData = GetRequiredProperty(cachedSnapshotType, "MetaData");
+            _snapshotTimeStamp = GetRequiredProperty(cachedSnapshotType, "TimeStamp");
+            _snapshotHasSystemMemoryResidentPages = GetRequiredProperty(cachedSnapshotType, "HasSystemMemoryResidentPages");
+            _snapshotCrawledData = GetRequiredProperty(cachedSnapshotType, "CrawledData");
+            _snapshotNativeObjects = GetRequiredField(cachedSnapshotType, "NativeObjects");
+            _snapshotNativeTypes = GetRequiredField(cachedSnapshotType, "NativeTypes");
+            _snapshotTypeDescriptions = GetRequiredField(cachedSnapshotType, "TypeDescriptions");
+
+            _nativeObjectsCount = GetRequiredField(nativeObjectsType, "Count");
+            _nativeObjectsNames = GetRequiredField(nativeObjectsType, "ObjectName");
+            _nativeObjectsSizes = GetRequiredField(nativeObjectsType, "Size");
+            _nativeObjectsTypeIndices = GetRequiredField(nativeObjectsType, "NativeTypeArrayIndex");
+            _nativeObjectsInstanceIds = GetRequiredField(nativeObjectsType, "InstanceId");
+
+            _nativeTypesNames = GetRequiredField(nativeTypesType, "TypeName");
+            _typeDescriptionsNames = GetRequiredField(typeDescriptionsType, "TypeDescriptionName");
+
+            _managedDataManagedObjects = GetRequiredField(managedDataType, "m_ManagedObjects");
+            _managedObjectTypeDescription = GetRequiredField(managedObjectInfoType, "ITypeDescription");
+            _managedObjectSize = GetRequiredField(managedObjectInfoType, "Size");
+
+            var metaDataType = _snapshotMetaData.PropertyType;
+            _metadataPlatform = GetRequiredField(metaDataType, "Platform");
+            _metadataUnityVersion = GetRequiredField(metaDataType, "UnityVersion");
+            _metadataIsEditorCapture = GetRequiredField(metaDataType, "IsEditorCapture");
+            _metadataCaptureFlags = GetRequiredField(metaDataType, "CaptureFlags");
+
+            _summaryRows = GetRequiredProperty(summaryModelType, "Rows");
+            _summaryRowName = GetRequiredProperty(summaryRowType, "Name");
+            _summaryRowBaseSize = GetRequiredProperty(summaryRowType, "BaseSize");
+            _summaryRowResidentSizeUnavailable = GetRequiredProperty(summaryRowType, "ResidentSizeUnavailable");
+            _memorySizeCommitted = GetRequiredField(memorySizeType, "Committed");
+            _memorySizeResident = GetRequiredField(memorySizeType, "Resident");
+        }
+
+        public static bool TryGet(out MemoryProfilerReflection reflection, out string unavailableReason)
+        {
+            if (_cached != null)
+            {
+                reflection = _cached;
+                unavailableReason = "";
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(_cachedUnavailableReason))
+            {
+                reflection = null;
+                unavailableReason = _cachedUnavailableReason;
+                return false;
+            }
+
+            try
+            {
+                var assembly = FindMemoryProfilerAssembly();
+                if (assembly == null)
+                    throw new InvalidOperationException("Assembly Unity.MemoryProfiler.Editor is not loaded.");
+
+                _cached = new MemoryProfilerReflection(assembly);
+                reflection = _cached;
+                unavailableReason = "";
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _cachedUnavailableReason = ex.Message;
+                reflection = null;
+                unavailableReason = _cachedUnavailableReason;
+                return false;
+            }
+        }
+
+        public object CreateFileReader()
+        {
+            return _fileReaderCtor.Invoke(null);
+        }
+
+        public string OpenFileReader(object reader, string path)
+        {
+            var result = _fileReaderOpen.Invoke(reader, new object[] { path });
+            return result?.ToString() ?? "Unknown";
+        }
+
+        public void CloseFileReader(object reader)
+        {
+            _fileReaderClose.Invoke(reader, null);
+        }
+
+        public object CreateCachedSnapshot(object reader)
+        {
+            return _cachedSnapshotCtor.Invoke(new[] { reader });
+        }
+
+        public void DisposeCachedSnapshot(object snapshot)
+        {
+            _cachedSnapshotDispose.Invoke(snapshot, null);
+        }
+
+        public void CrawlManagedData(object snapshot)
+        {
+            var enumerator = (IEnumerator)_managedDataCrawlerCrawl.Invoke(null, new[] { snapshot });
+            while (enumerator.MoveNext())
+            {
+            }
+        }
+
+        public SnapshotAnalysis ExtractAnalysis(object snapshot, string snapshotPath)
+        {
+            var fileInfo = new FileInfo(snapshotPath);
+            var categories = ExtractCategories(snapshot);
+            var nativeData = ExtractNativeData(snapshot);
+            var managedData = ExtractManagedData(snapshot);
+
+            return new SnapshotAnalysis
+            {
+                Path = fileInfo.FullName,
+                FileSize = fileInfo.Length,
+                FileMtimeTicks = fileInfo.LastWriteTimeUtc.Ticks,
+                Metadata = ExtractMetadata(snapshot),
+                Categories = categories,
+                NativeTypeStats = nativeData.TypeStats,
+                ManagedTypeStats = managedData.TypeStats,
+                TopNativeObjects = nativeData.TopObjects,
+                NativeObjectCount = nativeData.NativeObjectCount,
+                TotalNativeSize = nativeData.TotalNativeSize,
+                ManagedObjectCount = managedData.ManagedObjectCount,
+                TotalManagedObjectSize = managedData.TotalManagedObjectSize
+            };
+        }
+
+        private MemorySnapshotMetadataInfo ExtractMetadata(object snapshot)
+        {
+            var metadata = _snapshotMetaData.GetValue(snapshot);
+            var captureDate = (DateTime)_snapshotTimeStamp.GetValue(snapshot, null);
+
+            return new MemorySnapshotMetadataInfo
+            {
+                unityVersion = GetStringField(metadata, _metadataUnityVersion),
+                platform = GetStringField(metadata, _metadataPlatform),
+                isEditorCapture = (bool)_metadataIsEditorCapture.GetValue(metadata),
+                captureDate = captureDate.ToString("o"),
+                captureFlags = _metadataCaptureFlags.GetValue(metadata)?.ToString() ?? ""
+            };
+        }
+
+        private MemorySnapshotCategoryInfo[] ExtractCategories(object snapshot)
+        {
+            var hasResidentPages = (bool)_snapshotHasSystemMemoryResidentPages.GetValue(snapshot, null);
+            var builder = _summaryBuilderCtor.Invoke(new[] { snapshot, null });
+            var model = _summaryBuild.Invoke(builder, null);
+            var rows = (IEnumerable)_summaryRows.GetValue(model, null);
+            var categories = new List<MemorySnapshotCategoryInfo>();
+
+            foreach (var row in rows)
+            {
+                var size = _summaryRowBaseSize.GetValue(row, null);
+                var residentUnavailable = (bool)_summaryRowResidentSizeUnavailable.GetValue(row, null);
+                var residentAvailable = hasResidentPages && !residentUnavailable;
+
+                categories.Add(new MemorySnapshotCategoryInfo
+                {
+                    name = (string)_summaryRowName.GetValue(row, null),
+                    committed = ToLong((ulong)_memorySizeCommitted.GetValue(size)),
+                    resident = residentAvailable ? ToLong((ulong)_memorySizeResident.GetValue(size)) : 0,
+                    residentAvailable = residentAvailable
+                });
+            }
+
+            return categories.ToArray();
+        }
+
+        private NativeExtractionResult ExtractNativeData(object snapshot)
+        {
+            var nativeObjects = _snapshotNativeObjects.GetValue(snapshot);
+            var nativeTypes = _snapshotNativeTypes.GetValue(snapshot);
+
+            var objectCount = (long)_nativeObjectsCount.GetValue(nativeObjects);
+            var objectNames = (string[])_nativeObjectsNames.GetValue(nativeObjects);
+            var objectSizes = _nativeObjectsSizes.GetValue(nativeObjects);
+            var typeIndices = _nativeObjectsTypeIndices.GetValue(nativeObjects);
+            var instanceIds = _nativeObjectsInstanceIds.GetValue(nativeObjects);
+            var typeNames = (string[])_nativeTypesNames.GetValue(nativeTypes);
+
+            var typeStats = new MemorySnapshotNativeTypeStat[typeNames.Length];
+            for (var i = 0; i < typeNames.Length; i++)
+            {
+                typeStats[i] = new MemorySnapshotNativeTypeStat
+                {
+                    typeName = typeNames[i] ?? "",
+                    count = 0,
+                    totalSize = 0
+                };
+            }
+
+            var retainer = new NativeObjectRetainer(globalCapacity: 1000, perTypeCapacity: 50);
+            long totalNativeSize = 0;
+
+            for (long index = 0; index < objectCount; index++)
+            {
+                var typeIndex = ReadInt32(typeIndices, index);
+                if (typeIndex < 0 || typeIndex >= typeStats.Length)
+                    continue;
+
+                var size = ToLong(ReadUInt64(objectSizes, index));
+                var typeStat = typeStats[typeIndex];
+                typeStat.count++;
+                typeStat.totalSize += size;
+                totalNativeSize += size;
+
+                retainer.Add(new RetainedNativeObjectInfo
+                {
+                    NativeObjectIndex = index,
+                    Name = objectNames[index] ?? "",
+                    TypeName = typeStat.typeName,
+                    Size = size,
+                    InstanceId = ReadInstanceId(instanceIds, index)
+                });
+            }
+
+            return new NativeExtractionResult
+            {
+                TypeStats = typeStats,
+                TopObjects = retainer.Build(),
+                NativeObjectCount = objectCount,
+                TotalNativeSize = totalNativeSize
+            };
+        }
+
+        private ManagedExtractionResult ExtractManagedData(object snapshot)
+        {
+            var crawledData = _snapshotCrawledData.GetValue(snapshot, null);
+            if (crawledData == null)
+            {
+                return new ManagedExtractionResult
+                {
+                    TypeStats = Array.Empty<MemorySnapshotNativeTypeStat>()
+                };
+            }
+
+            var managedObjects = _managedDataManagedObjects.GetValue(crawledData);
+            var accessor = GetDynamicArrayStructFieldAccessor(managedObjects.GetType());
+            var objectCount = accessor.GetCount(managedObjects);
+
+            var typeDescriptions = _snapshotTypeDescriptions.GetValue(snapshot);
+            var typeNames = (string[])_typeDescriptionsNames.GetValue(typeDescriptions);
+            var statsByName = new Dictionary<string, MemorySnapshotNativeTypeStat>(StringComparer.Ordinal);
+            long totalManagedSize = 0;
+
+            for (long index = 0; index < objectCount; index++)
+            {
+                var typeIndex = accessor.ReadInt32(managedObjects, index, _managedObjectTypeDescription);
+                var size = accessor.ReadInt32(managedObjects, index, _managedObjectSize);
+                if (size < 0)
+                    size = 0;
+
+                var typeName = typeIndex >= 0 && typeIndex < typeNames.Length
+                    ? typeNames[typeIndex] ?? ""
+                    : "<unknown>";
+
+                if (!statsByName.TryGetValue(typeName, out var stat))
+                {
+                    stat = new MemorySnapshotNativeTypeStat
+                    {
+                        typeName = typeName,
+                        count = 0,
+                        totalSize = 0
+                    };
+                    statsByName[typeName] = stat;
+                }
+
+                stat.count++;
+                stat.totalSize += size;
+                totalManagedSize += size;
+            }
+
+            return new ManagedExtractionResult
+            {
+                TypeStats = statsByName.Values.ToArray(),
+                ManagedObjectCount = objectCount,
+                TotalManagedObjectSize = totalManagedSize
+            };
+        }
+
+        private static Assembly FindMemoryProfilerAssembly()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.GetName().Name == "Unity.MemoryProfiler.Editor")
+                    return assembly;
+            }
+
+            try
+            {
+                return Assembly.Load("Unity.MemoryProfiler.Editor");
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Type GetRequiredType(Assembly assembly, string name)
+        {
+            return assembly.GetType(name, throwOnError: true);
+        }
+
+        private static Type GetRequiredNestedType(Type type, string name)
+        {
+            var nested = type.GetNestedType(name, BindingFlags.Public | BindingFlags.NonPublic);
+            if (nested == null)
+                throw new MissingMemberException(type.FullName, name);
+            return nested;
+        }
+
+        private static ConstructorInfo GetRequiredConstructor(Type type, Type[] parameterTypes)
+        {
+            var constructor = type.GetConstructor(InstanceMembers, null, parameterTypes, null);
+            if (constructor == null)
+                throw new MissingMethodException(type.FullName, ".ctor");
+            return constructor;
+        }
+
+        private static MethodInfo GetRequiredMethod(Type type, string name, Type[] parameterTypes)
+        {
+            var method = type.GetMethod(name, InstanceMembers | StaticMembers, null, parameterTypes, null);
+            if (method == null)
+                throw new MissingMethodException(type.FullName, name);
+            return method;
+        }
+
+        private static PropertyInfo GetRequiredProperty(Type type, string name)
+        {
+            var property = type.GetProperty(name, InstanceMembers);
+            if (property == null)
+                throw new MissingMemberException(type.FullName, name);
+            return property;
+        }
+
+        private static FieldInfo GetRequiredField(Type type, string name)
+        {
+            var field = type.GetField(name, InstanceMembers);
+            if (field == null)
+                throw new MissingFieldException(type.FullName, name);
+            return field;
+        }
+
+        private static string GetStringField(object target, FieldInfo field)
+        {
+            return field.GetValue(target) as string ?? "";
+        }
+
+        private static long ToLong(ulong value)
+        {
+            return value > long.MaxValue ? long.MaxValue : (long)value;
+        }
+
+        private static uint ToUInt32(ulong value)
+        {
+            return value > uint.MaxValue ? uint.MaxValue : (uint)value;
+        }
+
+        private static int ReadInt32(object dynamicArray, long index)
+        {
+            var accessor = GetDynamicArrayAccessor(dynamicArray.GetType());
+            return Marshal.ReadInt32(accessor.GetElementPointer(dynamicArray, index));
+        }
+
+        private static ulong ReadUInt64(object dynamicArray, long index)
+        {
+            var accessor = GetDynamicArrayAccessor(dynamicArray.GetType());
+            return unchecked((ulong)Marshal.ReadInt64(accessor.GetElementPointer(dynamicArray, index)));
+        }
+
+        private static string ReadInstanceId(object dynamicArray, long index)
+        {
+            var accessor = GetDynamicArrayAccessor(dynamicArray.GetType());
+            var pointer = accessor.GetElementPointer(dynamicArray, index);
+
+            if (accessor.ElementSize >= 8)
+            {
+                var value = unchecked((ulong)Marshal.ReadInt64(pointer));
+                if (value <= uint.MaxValue)
+                    return unchecked((int)ToUInt32(value)).ToString();
+                return value.ToString();
+            }
+
+            if (accessor.ElementSize >= 4)
+                return Marshal.ReadInt32(pointer).ToString();
+
+            return "0";
+        }
+
+        private static DynamicArrayAccessor GetDynamicArrayAccessor(Type dynamicArrayType)
+        {
+            if (DynamicArrayAccessors.TryGetValue(dynamicArrayType, out var accessor))
+                return accessor;
+
+            accessor = new DynamicArrayAccessor(dynamicArrayType);
+            DynamicArrayAccessors[dynamicArrayType] = accessor;
+            return accessor;
+        }
+
+        private static DynamicArrayStructFieldAccessor GetDynamicArrayStructFieldAccessor(Type dynamicArrayType)
+        {
+            if (DynamicArrayStructFieldAccessors.TryGetValue(dynamicArrayType, out var accessor))
+                return accessor;
+
+            accessor = new DynamicArrayStructFieldAccessor(dynamicArrayType);
+            DynamicArrayStructFieldAccessors[dynamicArrayType] = accessor;
+            return accessor;
+        }
+
+        private sealed class NativeExtractionResult
+        {
+            public MemorySnapshotNativeTypeStat[] TypeStats;
+            public RetainedNativeObjectInfo[] TopObjects;
+            public long NativeObjectCount;
+            public long TotalNativeSize;
+        }
+
+        private sealed class ManagedExtractionResult
+        {
+            public MemorySnapshotNativeTypeStat[] TypeStats;
+            public long ManagedObjectCount;
+            public long TotalManagedObjectSize;
+        }
+
+        private sealed class DynamicArrayAccessor
+        {
+            private readonly FieldInfo _dataField;
+            public readonly int ElementSize;
+
+            public DynamicArrayAccessor(Type dynamicArrayType)
+            {
+                _dataField = GetRequiredField(dynamicArrayType, "m_Data");
+                var elementType = dynamicArrayType.GetGenericArguments()[0];
+                ElementSize = GetElementSize(elementType);
+            }
+
+            public unsafe IntPtr GetElementPointer(object dynamicArray, long index)
+            {
+                var boxedPointer = _dataField.GetValue(dynamicArray);
+                var pointer = new IntPtr(Pointer.Unbox(boxedPointer));
+                return new IntPtr(pointer.ToInt64() + checked(index * ElementSize));
+            }
+
+            private static int GetElementSize(Type elementType)
+            {
+                if (elementType == typeof(int))
+                    return sizeof(int);
+                if (elementType == typeof(long) || elementType == typeof(ulong))
+                    return sizeof(long);
+
+                try
+                {
+                    return Marshal.SizeOf(elementType);
+                }
+                catch (ArgumentException)
+                {
+                    foreach (var field in elementType.GetFields(InstanceMembers))
+                    {
+                        if (field.FieldType == typeof(long) || field.FieldType == typeof(ulong))
+                            return sizeof(long);
+                        if (field.FieldType == typeof(int) || field.FieldType == typeof(uint))
+                            return sizeof(int);
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        private sealed class DynamicArrayStructFieldAccessor
+        {
+            private readonly FieldInfo _dataField;
+            private readonly PropertyInfo _countProperty;
+            private readonly int _elementSize;
+
+            public DynamicArrayStructFieldAccessor(Type dynamicArrayType)
+            {
+                _dataField = GetRequiredField(dynamicArrayType, "m_Data");
+                _countProperty = GetRequiredProperty(dynamicArrayType, "Count");
+                _elementSize = GetElementSize(dynamicArrayType.GetGenericArguments()[0]);
+            }
+
+            public long GetCount(object dynamicArray)
+            {
+                return (long)_countProperty.GetValue(dynamicArray, null);
+            }
+
+            public int ReadInt32(object dynamicArray, long index, FieldInfo elementField)
+            {
+                var offset = (int)Marshal.OffsetOf(elementField.DeclaringType, elementField.Name);
+                return Marshal.ReadInt32(IntPtr.Add(GetElementPointer(dynamicArray, index), offset));
+            }
+
+            private unsafe IntPtr GetElementPointer(object dynamicArray, long index)
+            {
+                var boxedPointer = _dataField.GetValue(dynamicArray);
+                var pointer = new IntPtr(Pointer.Unbox(boxedPointer));
+                return new IntPtr(pointer.ToInt64() + checked(index * _elementSize));
+            }
+
+            private static int GetElementSize(Type elementType)
+            {
+                var unsafeUtility = Type.GetType("Unity.Collections.LowLevel.Unsafe.UnsafeUtility, UnityEngine.CoreModule");
+                var sizeOf = unsafeUtility?
+                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .FirstOrDefault(method =>
+                        method.Name == "SizeOf" &&
+                        method.IsGenericMethodDefinition &&
+                        method.GetParameters().Length == 0);
+
+                if (sizeOf != null)
+                    return (int)sizeOf.MakeGenericMethod(elementType).Invoke(null, null);
+
+                return Marshal.SizeOf(elementType);
+            }
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5395b61c5c5f8475998dc9cbf5859074
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs
@@ -1,0 +1,326 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotAllOfMemoryHandler : MemorySnapshotCommandHandler<MemorySnapshotAllOfMemoryRequest, MemorySnapshotAllOfMemoryResponse>
+    {
+        internal MemorySnapshotAllOfMemoryHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.AllOfMemory";
+        public override string Description => "Show a Memory Profiler All Of Memory style report with bounded sections and filters";
+
+        protected override ValueTask<MemorySnapshotAllOfMemoryResponse> ExecuteAsync(MemorySnapshotAllOfMemoryRequest request, CancellationToken cancellationToken)
+        {
+            var scope = MemorySnapshotAllOfMemoryScopeParser.Parse(request.scope);
+            if (scope == MemorySnapshotAllOfMemoryScope.Managed && !string.IsNullOrEmpty(request.nameFilter))
+            {
+                throw new CommandFailedException(
+                    "MemorySnapshot.AllOfMemory nameFilter applies only to native object rows; use scope=all/native with includeNativeObjects=true.",
+                    null);
+            }
+
+            var limit = MemorySnapshotFormatting.ClampLimit(request.limit);
+            var minSize = Math.Max(0, request.minSize);
+            var minSizeDelta = Math.Max(0, request.minSizeDelta);
+            var includeNativeTypes = request.includeNativeTypes && scope != MemorySnapshotAllOfMemoryScope.Managed;
+            var includeManagedTypes = request.includeManagedTypes && scope != MemorySnapshotAllOfMemoryScope.Native;
+            var includeNativeObjects = (request.includeNativeObjects || !string.IsNullOrEmpty(request.nameFilter)) &&
+                scope != MemorySnapshotAllOfMemoryScope.Managed;
+            var includeDiff = request.includeDiff && (!string.IsNullOrEmpty(request.baseSnapshot) || !string.IsNullOrEmpty(request.basePath));
+
+            var analysis = GetAnalysisByReferenceOrDefault(
+                request.snapshot,
+                request.path,
+                0,
+                out var cached,
+                out var analysisMs,
+                out var entry);
+
+            var response = new MemorySnapshotAllOfMemoryResponse
+            {
+                id = entry.id,
+                name = entry.name,
+                path = analysis.Path,
+                fileSize = analysis.FileSize,
+                analysisMs = analysisMs,
+                cached = cached,
+                metadata = analysis.Metadata,
+                total = MemorySnapshotAnalysisQueries.GetTotal(analysis),
+                categories = request.includeCategories ? analysis.Categories : Array.Empty<MemorySnapshotCategoryInfo>(),
+                filters = new MemorySnapshotAllOfMemoryFilterInfo
+                {
+                    scope = MemorySnapshotAllOfMemoryScopeParser.Name(scope),
+                    limit = limit,
+                    typeFilter = request.typeFilter ?? "",
+                    nameFilter = request.nameFilter ?? "",
+                    minSize = minSize,
+                    minSizeDelta = minSizeDelta,
+                    includeCategories = request.includeCategories,
+                    includeNativeTypes = includeNativeTypes,
+                    includeManagedTypes = includeManagedTypes,
+                    includeNativeObjects = includeNativeObjects,
+                    includeDiff = includeDiff
+                }
+            };
+
+            if (includeNativeTypes)
+                response.nativeTypes = ToTypeSection(analysis, MemorySnapshotScope.Native, request.typeFilter, limit, minSize);
+
+            if (includeManagedTypes)
+                response.managedTypes = ToTypeSection(analysis, MemorySnapshotScope.Managed, request.typeFilter, limit, minSize);
+
+            if (includeNativeObjects)
+            {
+                response.nativeObjects = new MemorySnapshotAllOfMemoryObjectSection
+                {
+                    included = true,
+                    objects = MemorySnapshotAnalysisQueries.GetTopObjects(
+                        analysis,
+                        request.typeFilter,
+                        request.nameFilter,
+                        limit,
+                        minSize,
+                        out var truncated),
+                    truncated = truncated
+                };
+            }
+
+            if (includeDiff)
+            {
+                var baseAnalysis = GetAnalysisByReference(
+                    request.baseSnapshot,
+                    request.basePath,
+                    out var baseCached,
+                    out var baseAnalysisMs,
+                    out var baseEntry);
+
+                response.analysisMs += baseAnalysisMs;
+                response.cached = response.cached && baseCached;
+                response.diff = new MemorySnapshotAllOfMemoryDiffSection
+                {
+                    included = true,
+                    @base = ToEndpoint(baseEntry, baseAnalysis),
+                    target = ToEndpoint(entry, analysis)
+                };
+
+                if (includeNativeTypes)
+                    response.diff.nativeTypes = ToDiffSection(baseAnalysis, analysis, MemorySnapshotScope.Native, request.typeFilter, limit, minSizeDelta);
+
+                if (includeManagedTypes)
+                    response.diff.managedTypes = ToDiffSection(baseAnalysis, analysis, MemorySnapshotScope.Managed, request.typeFilter, limit, minSizeDelta);
+            }
+
+            return new ValueTask<MemorySnapshotAllOfMemoryResponse>(response);
+        }
+
+        private static MemorySnapshotAllOfMemoryTypeSection ToTypeSection(
+            SnapshotAnalysis analysis,
+            MemorySnapshotScope scope,
+            string typeFilter,
+            int limit,
+            long minSize)
+        {
+            var result = MemorySnapshotAnalysisQueries.GetTopTypes(analysis, scope, typeFilter, limit, minSize);
+            return new MemorySnapshotAllOfMemoryTypeSection
+            {
+                included = true,
+                scope = MemorySnapshotFormatting.ScopeName(scope),
+                totalCount = MemorySnapshotAnalysisQueries.GetObjectCount(analysis, scope),
+                totalSize = MemorySnapshotAnalysisQueries.GetTotalSize(analysis, scope),
+                types = result.Types,
+                othersCount = result.OthersCount,
+                othersSize = result.OthersSize
+            };
+        }
+
+        private static MemorySnapshotAllOfMemoryTypeDiffSection ToDiffSection(
+            SnapshotAnalysis baseAnalysis,
+            SnapshotAnalysis targetAnalysis,
+            MemorySnapshotScope scope,
+            string typeFilter,
+            int limit,
+            long minSizeDelta)
+        {
+            var result = MemorySnapshotAnalysisQueries.GetDiffTypes(baseAnalysis, targetAnalysis, scope, typeFilter, limit, minSizeDelta);
+            return new MemorySnapshotAllOfMemoryTypeDiffSection
+            {
+                included = true,
+                scope = MemorySnapshotFormatting.ScopeName(scope),
+                totalSizeDelta = MemorySnapshotAnalysisQueries.GetTotalSize(targetAnalysis, scope) -
+                    MemorySnapshotAnalysisQueries.GetTotalSize(baseAnalysis, scope),
+                types = result.Types,
+                othersCount = result.OthersCount,
+                othersSize = result.OthersSize
+            };
+        }
+
+        private static MemorySnapshotAllOfMemoryEndpointInfo ToEndpoint(MemorySnapshotStatusEntry entry, SnapshotAnalysis analysis)
+        {
+            return new MemorySnapshotAllOfMemoryEndpointInfo
+            {
+                id = entry.id,
+                name = entry.name,
+                path = analysis.Path,
+                totalNativeSize = analysis.TotalNativeSize,
+                totalManagedSize = analysis.TotalManagedObjectSize,
+                totalSize = analysis.TotalNativeSize + analysis.TotalManagedObjectSize,
+                captureDate = analysis.Metadata.captureDate
+            };
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryRequest
+    {
+        public string snapshot;
+        public string path;
+        public string baseSnapshot;
+        public string basePath;
+        public string scope;
+        public int limit = 20;
+        public string typeFilter;
+        public string nameFilter;
+        public long minSize;
+        public long minSizeDelta;
+        public bool includeCategories = true;
+        public bool includeNativeTypes = true;
+        public bool includeManagedTypes = true;
+        public bool includeNativeObjects;
+        public bool includeDiff = true;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryResponse
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long fileSize;
+        public long analysisMs;
+        public bool cached;
+        public MemorySnapshotMetadataInfo metadata;
+        public MemorySnapshotTotalInfo total;
+        public MemorySnapshotCategoryInfo[] categories;
+        public MemorySnapshotAllOfMemoryTypeSection nativeTypes;
+        public MemorySnapshotAllOfMemoryTypeSection managedTypes;
+        public MemorySnapshotAllOfMemoryObjectSection nativeObjects;
+        public MemorySnapshotAllOfMemoryDiffSection diff;
+        public MemorySnapshotAllOfMemoryFilterInfo filters;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryFilterInfo
+    {
+        public string scope;
+        public int limit;
+        public string typeFilter;
+        public string nameFilter;
+        public long minSize;
+        public long minSizeDelta;
+        public bool includeCategories;
+        public bool includeNativeTypes;
+        public bool includeManagedTypes;
+        public bool includeNativeObjects;
+        public bool includeDiff;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryTypeSection
+    {
+        public bool included;
+        public string scope;
+        public long totalCount;
+        public long totalSize;
+        public MemorySnapshotNativeTypeStat[] types;
+        public long othersCount;
+        public long othersSize;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryObjectSection
+    {
+        public bool included;
+        public MemorySnapshotNativeObjectInfo[] objects;
+        public bool truncated;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryDiffSection
+    {
+        public bool included;
+        public MemorySnapshotAllOfMemoryEndpointInfo @base;
+        public MemorySnapshotAllOfMemoryEndpointInfo target;
+        public MemorySnapshotAllOfMemoryTypeDiffSection nativeTypes;
+        public MemorySnapshotAllOfMemoryTypeDiffSection managedTypes;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryEndpointInfo
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long totalNativeSize;
+        public long totalManagedSize;
+        public long totalSize;
+        public string captureDate;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryTypeDiffSection
+    {
+        public bool included;
+        public string scope;
+        public long totalSizeDelta;
+        public MemorySnapshotNativeTypeDiffInfo[] types;
+        public long othersCount;
+        public long othersSize;
+    }
+
+    internal enum MemorySnapshotAllOfMemoryScope
+    {
+        All,
+        Native,
+        Managed
+    }
+
+    internal static class MemorySnapshotAllOfMemoryScopeParser
+    {
+        public static MemorySnapshotAllOfMemoryScope Parse(string scope)
+        {
+            if (string.IsNullOrEmpty(scope) ||
+                string.Equals(scope, "all", StringComparison.OrdinalIgnoreCase))
+            {
+                return MemorySnapshotAllOfMemoryScope.All;
+            }
+
+            if (string.Equals(scope, MemorySnapshotFormatting.NativeScopeName, StringComparison.OrdinalIgnoreCase))
+                return MemorySnapshotAllOfMemoryScope.Native;
+
+            if (string.Equals(scope, MemorySnapshotFormatting.ManagedScopeName, StringComparison.OrdinalIgnoreCase))
+                return MemorySnapshotAllOfMemoryScope.Managed;
+
+            throw new CommandFailedException(
+                "Unknown All Of Memory scope: " + scope + ". Valid values are: all, native, managed.",
+                null);
+        }
+
+        public static string Name(MemorySnapshotAllOfMemoryScope scope)
+        {
+            if (scope == MemorySnapshotAllOfMemoryScope.Native)
+                return MemorySnapshotFormatting.NativeScopeName;
+
+            return scope == MemorySnapshotAllOfMemoryScope.Managed
+                ? MemorySnapshotFormatting.ManagedScopeName
+                : "all";
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1bb4c6e8a298440e8b548fcc65c63d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotCommandHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotCommandHandler.cs
@@ -1,0 +1,180 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.IO;
+using System.Linq;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public abstract class MemorySnapshotCommandHandler<TRequest, TResponse> : CommandHandler<TRequest, TResponse>
+    {
+        private const string DefaultSnapshotDirectory = "MemoryCaptures";
+        private readonly ISnapshotAnalyzer _analyzer;
+
+        private protected MemorySnapshotCommandHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+        {
+            Cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _analyzer = analyzer ?? throw new ArgumentNullException(nameof(analyzer));
+        }
+
+        private protected SnapshotAnalysisCache Cache { get; }
+
+        private protected SnapshotAnalysis GetAnalysis(string path, out bool cached, out long analysisMs)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new CommandFailedException("Snapshot path is required.", null);
+
+            return Cache.GetOrAnalyze(ResolvePath(path), _analyzer, out cached, out analysisMs);
+        }
+
+        private protected SnapshotAnalysis GetAnalysisOrDefault(string path, int defaultSnapshotIndex, out bool cached, out long analysisMs)
+        {
+            return Cache.GetOrAnalyze(
+                ResolveSnapshotPathOrDefault(path, defaultSnapshotIndex),
+                _analyzer,
+                out cached,
+                out analysisMs);
+        }
+
+        private protected SnapshotAnalysis GetAnalysisByReferenceOrDefault(
+            string snapshot,
+            string path,
+            int defaultSnapshotIndex,
+            out bool cached,
+            out long analysisMs,
+            out MemorySnapshotStatusEntry entry)
+        {
+            if (!string.IsNullOrEmpty(snapshot))
+            {
+                if (!string.IsNullOrEmpty(path))
+                    throw new CommandFailedException("Use either snapshot or path, not both.", null);
+
+                cached = true;
+                analysisMs = 0;
+                return Cache.GetLoaded(snapshot, out entry);
+            }
+
+            var analysis = Cache.GetOrAnalyze(
+                ResolveSnapshotPathOrDefault(path, defaultSnapshotIndex),
+                _analyzer,
+                out cached,
+                out analysisMs);
+            entry = Cache.ToStatusEntry(analysis);
+            return analysis;
+        }
+
+        private protected SnapshotAnalysis GetAnalysisByReference(
+            string snapshot,
+            string path,
+            out bool cached,
+            out long analysisMs,
+            out MemorySnapshotStatusEntry entry)
+        {
+            if (!string.IsNullOrEmpty(snapshot))
+            {
+                if (!string.IsNullOrEmpty(path))
+                    throw new CommandFailedException("Use either snapshot or path, not both.", null);
+
+                cached = true;
+                analysisMs = 0;
+                return Cache.GetLoaded(snapshot, out entry);
+            }
+
+            var analysis = GetAnalysis(path, out cached, out analysisMs);
+            entry = Cache.ToStatusEntry(analysis);
+            return analysis;
+        }
+
+        private protected SnapshotAnalysis LoadAnalysis(
+            string path,
+            string name,
+            bool replace,
+            out bool cached,
+            out long analysisMs,
+            out MemorySnapshotStatusEntry entry)
+        {
+            return Cache.LoadOrAnalyze(
+                ResolveSnapshotPathOrDefault(path, 0),
+                _analyzer,
+                name,
+                replace,
+                out cached,
+                out analysisMs,
+                out entry);
+        }
+
+        private protected string ResolveSnapshotPathOrDefault(string path, int defaultSnapshotIndex)
+        {
+            if (!string.IsNullOrEmpty(path))
+                return ResolvePath(path);
+
+            return MemorySnapshotPathResolver.ResolveDefaultSnapshot(
+                ResolvePath(DefaultSnapshotDirectory),
+                defaultSnapshotIndex);
+        }
+
+        private protected string ResolveDefaultSnapshotDirectory()
+        {
+            return ResolvePath(DefaultSnapshotDirectory);
+        }
+
+        private protected string GetDefaultCapturePath()
+        {
+            return ResolvePath(Path.Combine(DefaultSnapshotDirectory, $"snapshot_{DateTime.Now:yyyyMMdd_HHmmss}.snap"));
+        }
+
+        private protected string ToDisplayPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return "";
+
+            var fullPath = Path.GetFullPath(path);
+            if (!string.IsNullOrEmpty(ClientWorkingDirectory))
+            {
+                var cwd = Path.GetFullPath(ClientWorkingDirectory)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var prefix = cwd + Path.DirectorySeparatorChar;
+                if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return NormalizePath(fullPath.Substring(prefix.Length));
+            }
+
+            return NormalizePath(path);
+        }
+
+        internal static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/');
+        }
+    }
+
+    internal static class MemorySnapshotPathResolver
+    {
+        public static string ResolveDefaultSnapshot(string resolvedDirectory, int index)
+        {
+            var snapshots = ListSnapshots(resolvedDirectory);
+            if (index >= 0 && index < snapshots.Length)
+                return snapshots[index].FullName;
+
+            throw new CommandFailedException(
+                $"Need at least {index + 1} snapshot file(s) in {NormalizePath(resolvedDirectory)} but found {snapshots.Length}.",
+                null);
+        }
+
+        public static FileInfo[] ListSnapshots(string resolvedDirectory)
+        {
+            if (string.IsNullOrEmpty(resolvedDirectory) || !Directory.Exists(resolvedDirectory))
+                return Array.Empty<FileInfo>();
+
+            return Directory.EnumerateFiles(resolvedDirectory, "*.snap", SearchOption.TopDirectoryOnly)
+                .Select(path => new FileInfo(path))
+                .OrderByDescending(info => info.LastWriteTimeUtc)
+                .ThenByDescending(info => info.Name, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/');
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotCommandHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotCommandHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2eaa3c440f1c94c4c86a6d96619d9fdc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotDiffHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotDiffHandler.cs
@@ -1,0 +1,114 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotDiffHandler : MemorySnapshotCommandHandler<MemorySnapshotDiffRequest, MemorySnapshotDiffResponse>
+    {
+        internal MemorySnapshotDiffHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Diff";
+        public override string Description => "Compare native or managed type memory deltas between two memory snapshots";
+
+        protected override ValueTask<MemorySnapshotDiffResponse> ExecuteAsync(MemorySnapshotDiffRequest request, CancellationToken cancellationToken)
+        {
+            var scope = MemorySnapshotScopeParser.Parse(request.scope);
+            var minSizeDelta = Math.Max(0, request.minSizeDelta);
+            var baseAnalysis = GetAnalysisByReferenceOrDefault(
+                request.baseSnapshot,
+                request.basePath,
+                1,
+                out var baseCached,
+                out var baseAnalysisMs,
+                out var baseEntry);
+            var targetAnalysis = GetAnalysisByReferenceOrDefault(
+                request.targetSnapshot,
+                request.targetPath,
+                0,
+                out var targetCached,
+                out var targetAnalysisMs,
+                out var targetEntry);
+            var diff = MemorySnapshotAnalysisQueries.GetDiffTypes(
+                baseAnalysis,
+                targetAnalysis,
+                scope,
+                request.typeFilter,
+                request.limit,
+                minSizeDelta);
+
+            return new ValueTask<MemorySnapshotDiffResponse>(new MemorySnapshotDiffResponse
+            {
+                @base = new MemorySnapshotDiffEndpointInfo
+                {
+                    id = baseEntry.id,
+                    name = baseEntry.name,
+                    path = baseAnalysis.Path,
+                    totalNativeSize = baseAnalysis.TotalNativeSize,
+                    totalSize = MemorySnapshotAnalysisQueries.GetTotalSize(baseAnalysis, scope),
+                    captureDate = baseAnalysis.Metadata.captureDate
+                },
+                target = new MemorySnapshotDiffEndpointInfo
+                {
+                    id = targetEntry.id,
+                    name = targetEntry.name,
+                    path = targetAnalysis.Path,
+                    totalNativeSize = targetAnalysis.TotalNativeSize,
+                    totalSize = MemorySnapshotAnalysisQueries.GetTotalSize(targetAnalysis, scope),
+                    captureDate = targetAnalysis.Metadata.captureDate
+                },
+                analysisMs = baseAnalysisMs + targetAnalysisMs,
+                cached = baseCached && targetCached,
+                scope = MemorySnapshotFormatting.ScopeName(scope),
+                minSizeDelta = minSizeDelta,
+                types = diff.Types,
+                othersCount = diff.OthersCount,
+                othersSize = diff.OthersSize
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotDiffRequest
+    {
+        public string baseSnapshot;
+        public string basePath;
+        public string targetSnapshot;
+        public string targetPath;
+        public int limit = 20;
+        public string typeFilter;
+        public string scope;
+        public long minSizeDelta;
+    }
+
+    [Serializable]
+    public class MemorySnapshotDiffResponse
+    {
+        public MemorySnapshotDiffEndpointInfo @base;
+        public MemorySnapshotDiffEndpointInfo target;
+        public long analysisMs;
+        public bool cached;
+        public string scope;
+        public long minSizeDelta;
+        public MemorySnapshotNativeTypeDiffInfo[] types;
+        public long othersCount;
+        public long othersSize;
+    }
+
+    [Serializable]
+    public class MemorySnapshotDiffEndpointInfo
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long totalNativeSize;
+        public long totalSize;
+        public string captureDate;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotDiffHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotDiffHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1712eb686a1274cfd96f520ea92c08e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotListHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotListHandler.cs
@@ -1,0 +1,152 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Unity.Profiling.Memory;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotListHandler : MemorySnapshotCommandHandler<MemorySnapshotListRequest, MemorySnapshotListResponse>
+    {
+        internal MemorySnapshotListHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.List";
+        public override string Description => "List memory snapshot (.snap) files captured by MemorySnapshot.Capture, Profiler.TakeSnapshot, or the Memory Profiler window";
+
+        protected override ValueTask<MemorySnapshotListResponse> ExecuteAsync(MemorySnapshotListRequest request, CancellationToken cancellationToken)
+        {
+            var directory = string.IsNullOrEmpty(request.directory) ? "MemoryCaptures" : request.directory;
+            var resolvedDirectory = ResolvePath(directory);
+
+            if (!Directory.Exists(resolvedDirectory))
+            {
+                return new ValueTask<MemorySnapshotListResponse>(new MemorySnapshotListResponse
+                {
+                    entries = Array.Empty<MemorySnapshotListEntry>()
+                });
+            }
+
+            var entries = MemorySnapshotPathResolver.ListSnapshots(resolvedDirectory)
+                .Select(info => new MemorySnapshotListEntry
+                {
+                    path = ToDisplayPath(info.FullName),
+                    size = info.Length,
+                    lastModified = info.LastWriteTimeUtc.ToString("o")
+                })
+                .ToArray();
+
+            return new ValueTask<MemorySnapshotListResponse>(new MemorySnapshotListResponse
+            {
+                entries = entries
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotListRequest
+    {
+        public string directory = "MemoryCaptures";
+    }
+
+    [Serializable]
+    public class MemorySnapshotListResponse
+    {
+        public MemorySnapshotListEntry[] entries;
+    }
+
+    [Serializable]
+    public class MemorySnapshotListEntry
+    {
+        public string path;
+        public long size;
+        public string lastModified;
+    }
+
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotCaptureHandler : MemorySnapshotCommandHandler<MemorySnapshotCaptureRequest, MemorySnapshotCaptureResponse>
+    {
+        internal MemorySnapshotCaptureHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Capture";
+        public override string Description => "Capture a memory snapshot for MemorySnapshot analysis; Profiler.TakeSnapshot remains available as the generic profiler capture command";
+
+        protected override async ValueTask<MemorySnapshotCaptureResponse> ExecuteAsync(MemorySnapshotCaptureRequest request, CancellationToken cancellationToken)
+        {
+            var path = string.IsNullOrEmpty(request.path) ? GetDefaultCapturePath() : ResolvePath(request.path);
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            var captureFlags = ParseCaptureFlags(request.flags);
+            var tcs = new TaskCompletionSource<string>();
+
+            MemoryProfiler.TakeSnapshot(path, (filePath, success) =>
+            {
+                if (success)
+                    tcs.TrySetResult(filePath);
+                else
+                    tcs.TrySetException(new InvalidOperationException($"Failed to capture memory snapshot at: {path}"));
+            }, captureFlags);
+
+            var resultPath = await tcs.Task.WithCancellation(cancellationToken);
+
+            long size = 0;
+            if (File.Exists(resultPath))
+                size = new FileInfo(resultPath).Length;
+
+            return new MemorySnapshotCaptureResponse
+            {
+                path = resultPath,
+                size = size
+            };
+        }
+
+        private static CaptureFlags ParseCaptureFlags(string[] flags)
+        {
+            if (flags == null || flags.Length == 0)
+                return CaptureFlags.ManagedObjects | CaptureFlags.NativeObjects | CaptureFlags.NativeAllocations;
+
+            var result = (CaptureFlags)0;
+            foreach (var flag in flags)
+            {
+                if (string.IsNullOrWhiteSpace(flag))
+                    continue;
+
+                if (!Enum.TryParse(typeof(CaptureFlags), flag, ignoreCase: true, out var parsed))
+                {
+                    throw new CommandFailedException(
+                        $"Unknown memory snapshot capture flag: {flag}. Valid values are: {string.Join(", ", Enum.GetNames(typeof(CaptureFlags)))}.",
+                        null);
+                }
+
+                result |= (CaptureFlags)parsed;
+            }
+
+            return result;
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotCaptureRequest
+    {
+        public string path;
+        public string[] flags;
+    }
+
+    [Serializable]
+    public class MemorySnapshotCaptureResponse
+    {
+        public string path;
+        public long size;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotListHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotListHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92c6f777fe1954f25be8b02a723398ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotServiceInstaller.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotServiceInstaller.cs
@@ -1,0 +1,13 @@
+#if UNICLI_MEMORY_PROFILER
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class MemorySnapshotServiceInstaller : IServiceInstaller
+    {
+        public void Install(ServiceRegistry services)
+        {
+            services.AddSingleton(new SnapshotAnalysisCache());
+            services.AddSingleton<ISnapshotAnalyzer>(new MemoryProfilerPackageAnalyzer());
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotServiceInstaller.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotServiceInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 586403123ae2c470f984b62b6e55499c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotSummaryHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotSummaryHandler.cs
@@ -1,0 +1,269 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotSummaryHandler : MemorySnapshotCommandHandler<MemorySnapshotSummaryRequest, MemorySnapshotSummaryResponse>
+    {
+        internal MemorySnapshotSummaryHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Summary";
+        public override string Description => "Summarize a memory snapshot captured by MemorySnapshot.Capture, Profiler.TakeSnapshot, or the Memory Profiler window";
+
+        protected override ValueTask<MemorySnapshotSummaryResponse> ExecuteAsync(MemorySnapshotSummaryRequest request, CancellationToken cancellationToken)
+        {
+            var analysis = GetAnalysisByReferenceOrDefault(
+                request.snapshot,
+                request.path,
+                0,
+                out var cached,
+                out var analysisMs,
+                out var entry);
+
+            return new ValueTask<MemorySnapshotSummaryResponse>(new MemorySnapshotSummaryResponse
+            {
+                id = entry.id,
+                name = entry.name,
+                path = analysis.Path,
+                fileSize = analysis.FileSize,
+                analysisMs = analysisMs,
+                cached = cached,
+                metadata = analysis.Metadata,
+                categories = analysis.Categories,
+                total = MemorySnapshotAnalysisQueries.GetTotal(analysis)
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotSummaryRequest
+    {
+        public string snapshot;
+        public string path;
+    }
+
+    [Serializable]
+    public class MemorySnapshotSummaryResponse
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long fileSize;
+        public long analysisMs;
+        public bool cached;
+        public MemorySnapshotMetadataInfo metadata;
+        public MemorySnapshotCategoryInfo[] categories;
+        public MemorySnapshotTotalInfo total;
+    }
+
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotAnalyzeHandler : MemorySnapshotCommandHandler<MemorySnapshotAnalyzeRequest, MemorySnapshotAnalyzeResponse>
+    {
+        internal MemorySnapshotAnalyzeHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Analyze";
+        public override string Description => "Produce a compact MemorySnapshot report from the latest or specified snapshot, optionally diffed against a base snapshot";
+
+        protected override ValueTask<MemorySnapshotAnalyzeResponse> ExecuteAsync(MemorySnapshotAnalyzeRequest request, CancellationToken cancellationToken)
+        {
+            var limit = MemorySnapshotFormatting.ClampAnalyzeLimit(request.limit);
+            var analysis = GetAnalysisByReferenceOrDefault(
+                request.snapshot,
+                request.path,
+                0,
+                out var cached,
+                out var analysisMs,
+                out var entry);
+            var nativeTypes = MemorySnapshotAnalysisQueries.GetTopTypes(
+                analysis,
+                MemorySnapshotScope.Native,
+                typeFilter: "",
+                limit: limit,
+                minSize: 0);
+            var managedTypes = MemorySnapshotAnalysisQueries.GetTopTypes(
+                analysis,
+                MemorySnapshotScope.Managed,
+                typeFilter: "",
+                limit: limit,
+                minSize: 0);
+            var topObjects = MemorySnapshotAnalysisQueries.GetTopObjects(
+                analysis,
+                typeFilter: "",
+                nameFilter: "",
+                limit: limit,
+                minSize: 0,
+                out var topObjectsTruncated);
+
+            var response = new MemorySnapshotAnalyzeResponse
+            {
+                id = entry.id,
+                name = entry.name,
+                path = analysis.Path,
+                fileSize = analysis.FileSize,
+                analysisMs = analysisMs,
+                cached = cached,
+                summary = new MemorySnapshotAnalyzeSummarySection
+                {
+                    metadata = analysis.Metadata,
+                    categories = analysis.Categories,
+                    total = MemorySnapshotAnalysisQueries.GetTotal(analysis)
+                },
+                topNativeTypes = ToTypeSection(nativeTypes),
+                topManagedTypes = ToTypeSection(managedTypes),
+                topObjects = new MemorySnapshotAnalyzeObjectSection
+                {
+                    objects = topObjects,
+                    truncated = topObjectsTruncated
+                }
+            };
+
+            if (!string.IsNullOrEmpty(request.baseSnapshot) || !string.IsNullOrEmpty(request.basePath))
+            {
+                var baseAnalysis = GetAnalysisByReference(
+                    request.baseSnapshot,
+                    request.basePath,
+                    out var baseCached,
+                    out var baseAnalysisMs,
+                    out var baseEntry);
+                var nativeDiff = MemorySnapshotAnalysisQueries.GetDiffTypes(
+                    baseAnalysis,
+                    analysis,
+                    MemorySnapshotScope.Native,
+                    typeFilter: "",
+                    limit: limit,
+                    minSizeDelta: 0);
+                var managedDiff = MemorySnapshotAnalysisQueries.GetDiffTypes(
+                    baseAnalysis,
+                    analysis,
+                    MemorySnapshotScope.Managed,
+                    typeFilter: "",
+                    limit: limit,
+                    minSizeDelta: 0);
+
+                response.analysisMs += baseAnalysisMs;
+                response.cached = response.cached && baseCached;
+                response.diff = new MemorySnapshotAnalyzeDiffSection
+                {
+                    @base = new MemorySnapshotDiffEndpointInfo
+                    {
+                        id = baseEntry.id,
+                        name = baseEntry.name,
+                        path = baseAnalysis.Path,
+                        totalNativeSize = baseAnalysis.TotalNativeSize,
+                        totalSize = baseAnalysis.TotalNativeSize,
+                        captureDate = baseAnalysis.Metadata.captureDate
+                    },
+                    target = new MemorySnapshotDiffEndpointInfo
+                    {
+                        id = entry.id,
+                        name = entry.name,
+                        path = analysis.Path,
+                        totalNativeSize = analysis.TotalNativeSize,
+                        totalSize = analysis.TotalNativeSize,
+                        captureDate = analysis.Metadata.captureDate
+                    },
+                    nativeTypes = ToDiffSection(nativeDiff),
+                    managedTypes = ToDiffSection(managedDiff)
+                };
+            }
+
+            return new ValueTask<MemorySnapshotAnalyzeResponse>(response);
+        }
+
+        private static MemorySnapshotAnalyzeTypeSection ToTypeSection(MemorySnapshotTypeStatResult result)
+        {
+            return new MemorySnapshotAnalyzeTypeSection
+            {
+                types = result.Types,
+                othersCount = result.OthersCount,
+                othersSize = result.OthersSize
+            };
+        }
+
+        private static MemorySnapshotAnalyzeTypeDiffSection ToDiffSection(MemorySnapshotTypeDiffResult result)
+        {
+            return new MemorySnapshotAnalyzeTypeDiffSection
+            {
+                types = result.Types,
+                othersCount = result.OthersCount,
+                othersSize = result.OthersSize
+            };
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeRequest
+    {
+        public string snapshot;
+        public string path;
+        public string baseSnapshot;
+        public string basePath;
+        public int limit = 10;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeResponse
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long fileSize;
+        public long analysisMs;
+        public bool cached;
+        public MemorySnapshotAnalyzeSummarySection summary;
+        public MemorySnapshotAnalyzeTypeSection topNativeTypes;
+        public MemorySnapshotAnalyzeTypeSection topManagedTypes;
+        public MemorySnapshotAnalyzeObjectSection topObjects;
+        public MemorySnapshotAnalyzeDiffSection diff;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeSummarySection
+    {
+        public MemorySnapshotMetadataInfo metadata;
+        public MemorySnapshotCategoryInfo[] categories;
+        public MemorySnapshotTotalInfo total;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeTypeSection
+    {
+        public MemorySnapshotNativeTypeStat[] types;
+        public long othersCount;
+        public long othersSize;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeObjectSection
+    {
+        public MemorySnapshotNativeObjectInfo[] objects;
+        public bool truncated;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeDiffSection
+    {
+        public MemorySnapshotDiffEndpointInfo @base;
+        public MemorySnapshotDiffEndpointInfo target;
+        public MemorySnapshotAnalyzeTypeDiffSection nativeTypes;
+        public MemorySnapshotAnalyzeTypeDiffSection managedTypes;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAnalyzeTypeDiffSection
+    {
+        public MemorySnapshotNativeTypeDiffInfo[] types;
+        public long othersCount;
+        public long othersSize;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotSummaryHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotSummaryHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a3b3053f6fed45ebaeeeebcf46899c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotTopObjectsHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotTopObjectsHandler.cs
@@ -1,0 +1,110 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotTopObjectsHandler : MemorySnapshotCommandHandler<MemorySnapshotTopObjectsRequest, MemorySnapshotTopObjectsResponse>
+    {
+        internal MemorySnapshotTopObjectsHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.TopObjects";
+        public override string Description =>
+            "List largest retained native objects or native/managed type totals from a memory snapshot; object filters see at most the top 50 objects per native type";
+
+        protected override ValueTask<MemorySnapshotTopObjectsResponse> ExecuteAsync(MemorySnapshotTopObjectsRequest request, CancellationToken cancellationToken)
+        {
+            var scope = MemorySnapshotScopeParser.Parse(request.scope);
+            if (scope == MemorySnapshotScope.Managed && !string.IsNullOrEmpty(request.nameFilter))
+                throw new CommandFailedException("MemorySnapshot.TopObjects does not support nameFilter with scope=managed; managed scope is type aggregation only.", null);
+
+            var minSize = Math.Max(0, request.minSize);
+            var analysis = GetAnalysisByReferenceOrDefault(
+                request.snapshot,
+                request.path,
+                0,
+                out var cached,
+                out var analysisMs,
+                out var entry);
+            var groupByType = request.groupByType || scope == MemorySnapshotScope.Managed;
+
+            var response = new MemorySnapshotTopObjectsResponse
+            {
+                id = entry.id,
+                name = entry.name,
+                path = analysis.Path,
+                analysisMs = analysisMs,
+                cached = cached,
+                scope = MemorySnapshotFormatting.ScopeName(scope),
+                groupByType = groupByType,
+                objects = Array.Empty<MemorySnapshotNativeObjectInfo>(),
+                types = Array.Empty<MemorySnapshotNativeTypeStat>(),
+                truncated = false,
+                minSize = minSize
+            };
+
+            if (groupByType)
+            {
+                var result = MemorySnapshotAnalysisQueries.GetTopTypes(
+                    analysis,
+                    scope,
+                    request.typeFilter,
+                    request.limit,
+                    minSize);
+                response.types = result.Types;
+                response.othersCount = result.OthersCount;
+                response.othersSize = result.OthersSize;
+            }
+            else
+            {
+                response.objects = MemorySnapshotAnalysisQueries.GetTopObjects(
+                    analysis,
+                    request.typeFilter,
+                    request.nameFilter,
+                    request.limit,
+                    minSize,
+                    out var truncated);
+                response.truncated = truncated;
+            }
+
+            return new ValueTask<MemorySnapshotTopObjectsResponse>(response);
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotTopObjectsRequest
+    {
+        public string snapshot;
+        public string path;
+        public int limit = 20;
+        public string typeFilter;
+        public string nameFilter;
+        public string scope;
+        public long minSize;
+        public bool groupByType;
+    }
+
+    [Serializable]
+    public class MemorySnapshotTopObjectsResponse
+    {
+        public string id;
+        public string name;
+        public string path;
+        public long analysisMs;
+        public bool cached;
+        public string scope;
+        public bool groupByType;
+        public long minSize;
+        public MemorySnapshotNativeObjectInfo[] objects;
+        public MemorySnapshotNativeTypeStat[] types;
+        public long othersCount;
+        public long othersSize;
+        public bool truncated;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotTopObjectsHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotTopObjectsHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49047561e19964f1bb45d23f200ac182
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotUnloadHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotUnloadHandler.cs
@@ -1,0 +1,142 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotUnloadHandler : CommandHandler<MemorySnapshotUnloadRequest, MemorySnapshotUnloadResponse>
+    {
+        private readonly SnapshotAnalysisCache _cache;
+
+        internal MemorySnapshotUnloadHandler(SnapshotAnalysisCache cache)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        public override string CommandName => "MemorySnapshot.Unload";
+        public override string Description => "Clear cached MemorySnapshot analysis results, or release one loaded snapshot by id/name";
+
+        protected override ValueTask<MemorySnapshotUnloadResponse> ExecuteAsync(MemorySnapshotUnloadRequest request, CancellationToken cancellationToken)
+        {
+            return new ValueTask<MemorySnapshotUnloadResponse>(new MemorySnapshotUnloadResponse
+            {
+                releasedCount = _cache.Remove(request.snapshot)
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotUnloadRequest
+    {
+        public string snapshot;
+    }
+
+    [Serializable]
+    public class MemorySnapshotUnloadResponse
+    {
+        public int releasedCount;
+    }
+
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotLoadHandler : MemorySnapshotCommandHandler<MemorySnapshotLoadRequest, MemorySnapshotLoadResponse>
+    {
+        internal MemorySnapshotLoadHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Load";
+        public override string Description => "Analyze and name a memory snapshot so later MemorySnapshot commands can refer to it by id or name";
+
+        protected override ValueTask<MemorySnapshotLoadResponse> ExecuteAsync(MemorySnapshotLoadRequest request, CancellationToken cancellationToken)
+        {
+            LoadAnalysis(
+                request.path,
+                request.name,
+                request.replace,
+                out var cached,
+                out var analysisMs,
+                out var entry);
+
+            return new ValueTask<MemorySnapshotLoadResponse>(new MemorySnapshotLoadResponse
+            {
+                id = entry.id,
+                name = entry.name,
+                pinned = entry.pinned,
+                path = entry.path,
+                fileSize = entry.fileSize,
+                analyzedAtUtc = entry.analyzedAtUtc,
+                lastAccessedAtUtc = entry.lastAccessedAtUtc,
+                analysisMs = analysisMs,
+                cached = cached
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotLoadRequest
+    {
+        public string path;
+        public string name;
+        public bool replace;
+    }
+
+    [Serializable]
+    public class MemorySnapshotLoadResponse
+    {
+        public string id;
+        public string name;
+        public bool pinned;
+        public string path;
+        public long fileSize;
+        public string analyzedAtUtc;
+        public string lastAccessedAtUtc;
+        public long analysisMs;
+        public bool cached;
+    }
+
+    [Module("MemoryProfiler")]
+    public sealed class MemorySnapshotStatusHandler : MemorySnapshotCommandHandler<Unit, MemorySnapshotStatusResponse>
+    {
+        internal MemorySnapshotStatusHandler(SnapshotAnalysisCache cache, ISnapshotAnalyzer analyzer)
+            : base(cache, analyzer)
+        {
+        }
+
+        public override string CommandName => "MemorySnapshot.Status";
+        public override string Description => "Show cached MemorySnapshot analysis results";
+
+        protected override ValueTask<MemorySnapshotStatusResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            return new ValueTask<MemorySnapshotStatusResponse>(new MemorySnapshotStatusResponse
+            {
+                entries = Cache.GetEntries(),
+                capacity = Cache.GetCapacity()
+            });
+        }
+    }
+
+    [Serializable]
+    public class MemorySnapshotStatusResponse
+    {
+        public MemorySnapshotStatusEntry[] entries;
+        public int capacity;
+    }
+
+    [Serializable]
+    public class MemorySnapshotStatusEntry
+    {
+        public string id;
+        public string name;
+        public bool pinned;
+        public string path;
+        public long fileSize;
+        public string analyzedAtUtc;
+        public string lastAccessedAtUtc;
+        public long analysisMs;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotUnloadHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotUnloadHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f798bb5052c93418f9bf410d38ef4e04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs
@@ -1,0 +1,537 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal sealed class SnapshotAnalysis
+    {
+        public string Path;
+        public long FileSize;
+        public long FileMtimeTicks;
+        public string SnapshotId;
+        public string SnapshotName;
+        public bool Pinned;
+        public string AnalyzedAtUtc;
+        public string LastAccessedAtUtc;
+        public long AnalysisMs;
+        public MemorySnapshotMetadataInfo Metadata;
+        public MemorySnapshotCategoryInfo[] Categories;
+        public MemorySnapshotNativeTypeStat[] NativeTypeStats;
+        public MemorySnapshotNativeTypeStat[] ManagedTypeStats;
+        public RetainedNativeObjectInfo[] TopNativeObjects;
+        public long NativeObjectCount;
+        public long TotalNativeSize;
+        public long ManagedObjectCount;
+        public long TotalManagedObjectSize;
+    }
+
+    internal sealed class RetainedNativeObjectInfo
+    {
+        public long NativeObjectIndex;
+        public string Name;
+        public string TypeName;
+        public long Size;
+        public string InstanceId;
+
+        public MemorySnapshotNativeObjectInfo ToResponse()
+        {
+            return new MemorySnapshotNativeObjectInfo
+            {
+                name = Name,
+                typeName = TypeName,
+                size = Size,
+                instanceId = InstanceId
+            };
+        }
+    }
+
+    internal sealed class NativeObjectRetainer
+    {
+        private readonly TopObjectSet _globalTopObjects;
+        private readonly Dictionary<string, TopObjectSet> _topObjectsByType =
+            new Dictionary<string, TopObjectSet>(StringComparer.Ordinal);
+        private readonly int _perTypeCapacity;
+
+        public NativeObjectRetainer(int globalCapacity, int perTypeCapacity)
+        {
+            _globalTopObjects = new TopObjectSet(globalCapacity);
+            _perTypeCapacity = perTypeCapacity;
+        }
+
+        public void Add(RetainedNativeObjectInfo item)
+        {
+            _globalTopObjects.Add(item);
+
+            if (!_topObjectsByType.TryGetValue(item.TypeName, out var perType))
+            {
+                perType = new TopObjectSet(_perTypeCapacity);
+                _topObjectsByType[item.TypeName] = perType;
+            }
+
+            perType.Add(item);
+        }
+
+        public RetainedNativeObjectInfo[] Build()
+        {
+            var byIndex = new Dictionary<long, RetainedNativeObjectInfo>();
+            AddRange(byIndex, _globalTopObjects.Items);
+
+            foreach (var set in _topObjectsByType.Values)
+                AddRange(byIndex, set.Items);
+
+            return byIndex.Values
+                .OrderByDescending(item => item.Size)
+                .ThenBy(item => item.TypeName, StringComparer.Ordinal)
+                .ThenBy(item => item.Name, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static void AddRange(Dictionary<long, RetainedNativeObjectInfo> byIndex, IEnumerable<RetainedNativeObjectInfo> items)
+        {
+            foreach (var item in items)
+                byIndex[item.NativeObjectIndex] = item;
+        }
+
+        private sealed class TopObjectSet
+        {
+            private readonly int _capacity;
+            private readonly List<RetainedNativeObjectInfo> _items;
+            private int _minIndex = -1;
+            private long _minSize = long.MaxValue;
+
+            public TopObjectSet(int capacity)
+            {
+                _capacity = Math.Max(0, capacity);
+                _items = new List<RetainedNativeObjectInfo>(_capacity);
+            }
+
+            public IEnumerable<RetainedNativeObjectInfo> Items => _items;
+
+            public void Add(RetainedNativeObjectInfo item)
+            {
+                if (_capacity <= 0)
+                    return;
+
+                if (_items.Count < _capacity)
+                {
+                    _items.Add(item);
+                    if (item.Size < _minSize)
+                    {
+                        _minSize = item.Size;
+                        _minIndex = _items.Count - 1;
+                    }
+                    return;
+                }
+
+                if (item.Size <= _minSize)
+                    return;
+
+                _items[_minIndex] = item;
+                RecomputeMinimum();
+            }
+
+            private void RecomputeMinimum()
+            {
+                _minIndex = 0;
+                _minSize = _items[0].Size;
+
+                for (var i = 1; i < _items.Count; i++)
+                {
+                    if (_items[i].Size >= _minSize)
+                        continue;
+
+                    _minSize = _items[i].Size;
+                    _minIndex = i;
+                }
+            }
+        }
+    }
+
+    internal static class MemorySnapshotAnalysisQueries
+    {
+        public static MemorySnapshotNativeObjectInfo[] GetTopObjects(
+            SnapshotAnalysis analysis,
+            string typeFilter,
+            string nameFilter,
+            int limit,
+            out bool truncated)
+        {
+            return GetTopObjects(analysis, typeFilter, nameFilter, limit, 0, out truncated);
+        }
+
+        public static MemorySnapshotNativeObjectInfo[] GetTopObjects(
+            SnapshotAnalysis analysis,
+            string typeFilter,
+            string nameFilter,
+            int limit,
+            long minSize,
+            out bool truncated)
+        {
+            var filtered = analysis.TopNativeObjects
+                .Where(item => item.Size >= minSize && Matches(item.TypeName, typeFilter) && Matches(item.Name, nameFilter))
+                .OrderByDescending(item => item.Size)
+                .ThenBy(item => item.TypeName, StringComparer.Ordinal)
+                .ThenBy(item => item.Name, StringComparer.Ordinal)
+                .ToArray();
+
+            var clampedLimit = MemorySnapshotFormatting.ClampLimit(limit);
+            truncated = filtered.Length > clampedLimit || MayHaveUnretainedMatches(analysis, typeFilter, nameFilter, filtered.Length);
+
+            return filtered
+                .Take(clampedLimit)
+                .Select(item => item.ToResponse())
+                .ToArray();
+        }
+
+        public static MemorySnapshotNativeTypeStat[] GetTopTypes(SnapshotAnalysis analysis, string typeFilter, int limit)
+        {
+            return GetTopTypes(analysis, MemorySnapshotScope.Native, typeFilter, limit, 0).Types;
+        }
+
+        public static MemorySnapshotTypeStatResult GetTopTypes(
+            SnapshotAnalysis analysis,
+            MemorySnapshotScope scope,
+            string typeFilter,
+            int limit,
+            long minSize)
+        {
+            return GetTopTypes(GetTypeStats(analysis, scope), typeFilter, limit, minSize);
+        }
+
+        public static MemorySnapshotTypeStatResult GetTopTypes(
+            MemorySnapshotNativeTypeStat[] stats,
+            string typeFilter,
+            int limit,
+            long minSize)
+        {
+            var clampedLimit = MemorySnapshotFormatting.ClampLimit(limit);
+            var rows = (stats ?? Array.Empty<MemorySnapshotNativeTypeStat>())
+                .Where(stat => stat.count > 0 && Matches(stat.typeName, typeFilter))
+                .OrderByDescending(stat => stat.totalSize)
+                .ThenBy(stat => stat.typeName, StringComparer.Ordinal)
+                .ToArray();
+
+            var included = new List<MemorySnapshotNativeTypeStat>();
+            long othersCount = 0;
+            long othersSize = 0;
+
+            foreach (var row in rows)
+            {
+                if (row.totalSize < minSize || included.Count >= clampedLimit)
+                {
+                    othersCount++;
+                    othersSize += row.totalSize;
+                    continue;
+                }
+
+                included.Add(row);
+            }
+
+            return new MemorySnapshotTypeStatResult
+            {
+                Types = included.ToArray(),
+                OthersCount = othersCount,
+                OthersSize = othersSize
+            };
+        }
+
+        public static MemorySnapshotNativeTypeDiffInfo[] GetDiffTypes(
+            SnapshotAnalysis baseAnalysis,
+            SnapshotAnalysis targetAnalysis,
+            string typeFilter,
+            int limit)
+        {
+            return GetDiffTypes(baseAnalysis, targetAnalysis, MemorySnapshotScope.Native, typeFilter, limit, 0).Types;
+        }
+
+        public static MemorySnapshotTypeDiffResult GetDiffTypes(
+            SnapshotAnalysis baseAnalysis,
+            SnapshotAnalysis targetAnalysis,
+            MemorySnapshotScope scope,
+            string typeFilter,
+            int limit,
+            long minSizeDelta)
+        {
+            return GetDiffTypes(
+                GetTypeStats(baseAnalysis, scope),
+                GetTypeStats(targetAnalysis, scope),
+                typeFilter,
+                limit,
+                minSizeDelta);
+        }
+
+        public static MemorySnapshotTypeDiffResult GetDiffTypes(
+            MemorySnapshotNativeTypeStat[] baseTypeStats,
+            MemorySnapshotNativeTypeStat[] targetTypeStats,
+            string typeFilter,
+            int limit,
+            long minSizeDelta)
+        {
+            var clampedLimit = MemorySnapshotFormatting.ClampLimit(limit);
+            var baseStats = (baseTypeStats ?? Array.Empty<MemorySnapshotNativeTypeStat>())
+                .ToDictionary(stat => stat.typeName, StringComparer.Ordinal);
+            var targetStats = (targetTypeStats ?? Array.Empty<MemorySnapshotNativeTypeStat>())
+                .ToDictionary(stat => stat.typeName, StringComparer.Ordinal);
+            var names = new HashSet<string>(baseStats.Keys, StringComparer.Ordinal);
+            names.UnionWith(targetStats.Keys);
+
+            var rows = new List<MemorySnapshotNativeTypeDiffInfo>();
+            foreach (var name in names)
+            {
+                if (!Matches(name, typeFilter))
+                    continue;
+
+                baseStats.TryGetValue(name, out var baseStat);
+                targetStats.TryGetValue(name, out var targetStat);
+
+                var baseCount = baseStat?.count ?? 0;
+                var targetCount = targetStat?.count ?? 0;
+                var baseSize = baseStat?.totalSize ?? 0;
+                var targetSize = targetStat?.totalSize ?? 0;
+                var countDelta = targetCount - baseCount;
+                var sizeDelta = targetSize - baseSize;
+
+                if (countDelta == 0 && sizeDelta == 0)
+                    continue;
+
+                rows.Add(new MemorySnapshotNativeTypeDiffInfo
+                {
+                    typeName = name,
+                    baseCount = baseCount,
+                    targetCount = targetCount,
+                    countDelta = countDelta,
+                    baseSize = baseSize,
+                    targetSize = targetSize,
+                    sizeDelta = sizeDelta
+                });
+            }
+
+            var sortedRows = rows
+                .OrderByDescending(row => Math.Abs(row.sizeDelta))
+                .ThenBy(row => row.typeName, StringComparer.Ordinal)
+                .ToArray();
+
+            var included = new List<MemorySnapshotNativeTypeDiffInfo>();
+            long othersCount = 0;
+            long othersSize = 0;
+
+            foreach (var row in sortedRows)
+            {
+                var absoluteDelta = SafeAbs(row.sizeDelta);
+                if (absoluteDelta < minSizeDelta || included.Count >= clampedLimit)
+                {
+                    othersCount++;
+                    othersSize += absoluteDelta;
+                    continue;
+                }
+
+                included.Add(row);
+            }
+
+            return new MemorySnapshotTypeDiffResult
+            {
+                Types = included.ToArray(),
+                OthersCount = othersCount,
+                OthersSize = othersSize
+            };
+        }
+
+        public static MemorySnapshotTotalInfo GetTotal(SnapshotAnalysis analysis)
+        {
+            long committed = 0;
+            long resident = 0;
+            var residentAvailable = false;
+
+            foreach (var category in analysis.Categories)
+            {
+                committed += category.committed;
+                if (category.residentAvailable)
+                {
+                    resident += category.resident;
+                    residentAvailable = true;
+                }
+            }
+
+            return new MemorySnapshotTotalInfo
+            {
+                committed = committed,
+                resident = resident,
+                residentAvailable = residentAvailable
+            };
+        }
+
+        public static MemorySnapshotNativeTypeStat[] GetTypeStats(SnapshotAnalysis analysis, MemorySnapshotScope scope)
+        {
+            return scope == MemorySnapshotScope.Managed
+                ? analysis.ManagedTypeStats ?? Array.Empty<MemorySnapshotNativeTypeStat>()
+                : analysis.NativeTypeStats ?? Array.Empty<MemorySnapshotNativeTypeStat>();
+        }
+
+        public static long GetObjectCount(SnapshotAnalysis analysis, MemorySnapshotScope scope)
+        {
+            return scope == MemorySnapshotScope.Managed ? analysis.ManagedObjectCount : analysis.NativeObjectCount;
+        }
+
+        public static long GetTotalSize(SnapshotAnalysis analysis, MemorySnapshotScope scope)
+        {
+            return scope == MemorySnapshotScope.Managed ? analysis.TotalManagedObjectSize : analysis.TotalNativeSize;
+        }
+
+        private static bool Matches(string value, string filter)
+        {
+            return string.IsNullOrEmpty(filter)
+                || (value ?? "").IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static long SafeAbs(long value)
+        {
+            return value == long.MinValue ? long.MaxValue : Math.Abs(value);
+        }
+
+        private static bool MayHaveUnretainedMatches(
+            SnapshotAnalysis analysis,
+            string typeFilter,
+            string nameFilter,
+            int retainedMatchingCount)
+        {
+            if (analysis.NativeObjectCount <= analysis.TopNativeObjects.Length)
+                return false;
+
+            if (!string.IsNullOrEmpty(nameFilter))
+                return true;
+
+            var matchingObjectCount = analysis.NativeTypeStats
+                .Where(stat => Matches(stat.typeName, typeFilter))
+                .Sum(stat => stat.count);
+
+            return matchingObjectCount > retainedMatchingCount;
+        }
+    }
+
+    internal static class MemorySnapshotFormatting
+    {
+        public const string NativeScopeName = "native";
+        public const string ManagedScopeName = "managed";
+
+        public static int ClampLimit(int limit)
+        {
+            if (limit <= 0)
+                return 20;
+            if (limit > 200)
+                return 200;
+            return limit;
+        }
+
+        public static int ClampAnalyzeLimit(int limit)
+        {
+            if (limit <= 0)
+                return 10;
+            if (limit > 50)
+                return 50;
+            return limit;
+        }
+
+        public static string ScopeName(MemorySnapshotScope scope)
+        {
+            return scope == MemorySnapshotScope.Managed ? ManagedScopeName : NativeScopeName;
+        }
+    }
+
+    internal enum MemorySnapshotScope
+    {
+        Native,
+        Managed
+    }
+
+    internal static class MemorySnapshotScopeParser
+    {
+        public static MemorySnapshotScope Parse(string scope)
+        {
+            if (string.IsNullOrEmpty(scope) ||
+                string.Equals(scope, MemorySnapshotFormatting.NativeScopeName, StringComparison.OrdinalIgnoreCase))
+            {
+                return MemorySnapshotScope.Native;
+            }
+
+            if (string.Equals(scope, MemorySnapshotFormatting.ManagedScopeName, StringComparison.OrdinalIgnoreCase))
+                return MemorySnapshotScope.Managed;
+
+            throw new CommandFailedException(
+                "Unknown memory snapshot scope: " + scope + ". Valid values are: native, managed.",
+                null);
+        }
+    }
+
+    internal sealed class MemorySnapshotTypeStatResult
+    {
+        public MemorySnapshotNativeTypeStat[] Types;
+        public long OthersCount;
+        public long OthersSize;
+    }
+
+    internal sealed class MemorySnapshotTypeDiffResult
+    {
+        public MemorySnapshotNativeTypeDiffInfo[] Types;
+        public long OthersCount;
+        public long OthersSize;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotMetadataInfo
+    {
+        public string unityVersion;
+        public string platform;
+        public bool isEditorCapture;
+        public string captureDate;
+        public string captureFlags;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotCategoryInfo
+    {
+        public string name;
+        public long committed;
+        public long resident;
+        public bool residentAvailable;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotTotalInfo
+    {
+        public long committed;
+        public long resident;
+        public bool residentAvailable;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotNativeTypeStat
+    {
+        public string typeName;
+        public long count;
+        public long totalSize;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotNativeObjectInfo
+    {
+        public string name;
+        public string typeName;
+        public long size;
+        public string instanceId;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotNativeTypeDiffInfo
+    {
+        public string typeName;
+        public long baseCount;
+        public long targetCount;
+        public long countDelta;
+        public long baseSize;
+        public long targetSize;
+        public long sizeDelta;
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a8e0a7f4ac60429781a0ce96c7f30e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysisCache.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysisCache.cs
@@ -1,0 +1,381 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal sealed class SnapshotAnalysisCache
+    {
+        private const int Capacity = 8;
+
+        private readonly object _gate = new object();
+        private readonly Dictionary<string, LinkedListNode<CacheEntry>> _entries =
+            new Dictionary<string, LinkedListNode<CacheEntry>>();
+        private readonly Dictionary<string, string> _entryKeysById =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _entryKeysByName =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly LinkedList<CacheEntry> _lru = new LinkedList<CacheEntry>();
+
+        public SnapshotAnalysis GetOrAnalyze(
+            string snapshotPath,
+            ISnapshotAnalyzer analyzer,
+            out bool cached,
+            out long analysisMs)
+        {
+            return GetOrAnalyze(
+                snapshotPath,
+                analyzer,
+                name: "",
+                pin: false,
+                replace: false,
+                out cached,
+                out analysisMs,
+                out _);
+        }
+
+        public SnapshotAnalysis LoadOrAnalyze(
+            string snapshotPath,
+            ISnapshotAnalyzer analyzer,
+            string name,
+            bool replace,
+            out bool cached,
+            out long analysisMs,
+            out MemorySnapshotStatusEntry entry)
+        {
+            return GetOrAnalyze(
+                snapshotPath,
+                analyzer,
+                name,
+                pin: true,
+                replace,
+                out cached,
+                out analysisMs,
+                out entry);
+        }
+
+        public SnapshotAnalysis GetLoaded(string snapshot, out MemorySnapshotStatusEntry entry)
+        {
+            if (string.IsNullOrEmpty(snapshot))
+                throw new CommandFailedException("Snapshot id or name is required.", null);
+
+            lock (_gate)
+            {
+                if (!TryGetNodeBySnapshot(snapshot, out var node))
+                {
+                    throw new CommandFailedException(
+                        $"Loaded memory snapshot not found: {snapshot}. Use MemorySnapshot.Status to list loaded snapshots, or MemorySnapshot.Load to name one.",
+                        null);
+                }
+
+                Touch(node);
+                entry = ToStatusEntry(node.Value.Analysis);
+                return node.Value.Analysis;
+            }
+        }
+
+        public int Remove(string snapshot)
+        {
+            if (string.IsNullOrEmpty(snapshot))
+                return Clear();
+
+            lock (_gate)
+            {
+                if (!TryGetNodeBySnapshot(snapshot, out var node))
+                    return 0;
+
+                RemoveNode(node);
+                return 1;
+            }
+        }
+
+        private SnapshotAnalysis GetOrAnalyze(
+            string snapshotPath,
+            ISnapshotAnalyzer analyzer,
+            string name,
+            bool pin,
+            bool replace,
+            out bool cached,
+            out long analysisMs,
+            out MemorySnapshotStatusEntry entry)
+        {
+            if (string.IsNullOrEmpty(snapshotPath))
+                throw new CommandFailedException("Snapshot path is required.", null);
+
+            if (!File.Exists(snapshotPath))
+                throw new CommandFailedException($"Snapshot file not found: {snapshotPath}", null);
+
+            if (!analyzer.IsAvailable(out var unavailableReason))
+            {
+                throw new CommandFailedException(
+                    "Memory Profiler package internals are not accessible (com.unity.memoryprofiler 1.1.x). " +
+                    "UniCli MemorySnapshot commands are verified against 1.1.x. Reason: " + unavailableReason,
+                    null);
+            }
+
+            var fileInfo = new FileInfo(snapshotPath);
+            var key = MakeKey(fileInfo);
+            var id = MakeId(key);
+            var resolvedName = pin ? ResolveName(name, fileInfo) : "";
+
+            lock (_gate)
+            {
+                if (_entries.TryGetValue(key, out var node))
+                {
+                    if (pin)
+                        ApplyName(node.Value.Analysis, key, resolvedName, replace);
+
+                    Touch(node);
+                    cached = true;
+                    analysisMs = 0;
+                    entry = ToStatusEntry(node.Value.Analysis);
+                    return node.Value.Analysis;
+                }
+
+                EnsureCacheCanAcceptNewEntry(pin, resolvedName, replace);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var analysis = analyzer.Analyze(fileInfo.FullName);
+            stopwatch.Stop();
+            analysisMs = stopwatch.ElapsedMilliseconds;
+
+            analysis.Path = fileInfo.FullName;
+            analysis.FileSize = fileInfo.Length;
+            analysis.FileMtimeTicks = fileInfo.LastWriteTimeUtc.Ticks;
+            analysis.SnapshotId = id;
+            analysis.SnapshotName = resolvedName;
+            analysis.Pinned = pin;
+            analysis.AnalyzedAtUtc = DateTime.UtcNow.ToString("o");
+            analysis.LastAccessedAtUtc = analysis.AnalyzedAtUtc;
+            analysis.AnalysisMs = analysisMs;
+
+            lock (_gate)
+            {
+                if (pin)
+                    EnsureNameAvailable(resolvedName, key, replace);
+
+                var node = _lru.AddFirst(new CacheEntry(key, analysis));
+                _entries[key] = node;
+                _entryKeysById[id] = key;
+                if (pin)
+                    _entryKeysByName[resolvedName] = key;
+
+                EvictIfNeeded();
+                entry = ToStatusEntry(analysis);
+            }
+
+            cached = false;
+            return analysis;
+        }
+
+        public MemorySnapshotStatusEntry[] GetEntries()
+        {
+            lock (_gate)
+            {
+                return _lru
+                    .Select(entry => new MemorySnapshotStatusEntry
+                    {
+                        id = entry.Analysis.SnapshotId,
+                        name = entry.Analysis.SnapshotName,
+                        pinned = entry.Analysis.Pinned,
+                        path = entry.Analysis.Path,
+                        fileSize = entry.Analysis.FileSize,
+                        analyzedAtUtc = entry.Analysis.AnalyzedAtUtc,
+                        lastAccessedAtUtc = entry.Analysis.LastAccessedAtUtc,
+                        analysisMs = entry.Analysis.AnalysisMs
+                    })
+                    .ToArray();
+            }
+        }
+
+        public int GetCapacity()
+        {
+            return Capacity;
+        }
+
+        public int Clear()
+        {
+            lock (_gate)
+            {
+                var count = _entries.Count;
+                _entries.Clear();
+                _entryKeysById.Clear();
+                _entryKeysByName.Clear();
+                _lru.Clear();
+                return count;
+            }
+        }
+
+        private void Touch(LinkedListNode<CacheEntry> node)
+        {
+            node.Value.Analysis.LastAccessedAtUtc = DateTime.UtcNow.ToString("o");
+            _lru.Remove(node);
+            _lru.AddFirst(node);
+        }
+
+        private bool TryGetNodeBySnapshot(string snapshot, out LinkedListNode<CacheEntry> node)
+        {
+            if (_entryKeysById.TryGetValue(snapshot, out var key) ||
+                _entryKeysByName.TryGetValue(snapshot, out key))
+            {
+                return _entries.TryGetValue(key, out node);
+            }
+
+            node = null;
+            return false;
+        }
+
+        private void ApplyName(SnapshotAnalysis analysis, string key, string name, bool replace)
+        {
+            EnsureNameAvailable(name, key, replace);
+
+            if (!string.Equals(analysis.SnapshotName, name, StringComparison.OrdinalIgnoreCase) &&
+                _entryKeysByName.TryGetValue(analysis.SnapshotName, out var existingKey) &&
+                string.Equals(existingKey, key, StringComparison.Ordinal))
+            {
+                _entryKeysByName.Remove(analysis.SnapshotName);
+            }
+
+            analysis.SnapshotName = name;
+            analysis.Pinned = true;
+            _entryKeysByName[name] = key;
+        }
+
+        private void EnsureNameAvailable(string name, string key, bool replace)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new CommandFailedException("Snapshot name is required.", null);
+
+            if (!_entryKeysByName.TryGetValue(name, out var existingKey) ||
+                string.Equals(existingKey, key, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (!replace)
+            {
+                throw new CommandFailedException(
+                    $"Loaded memory snapshot name is already in use: {name}. Pass replace=true to reassign it.",
+                    null);
+            }
+
+            if (_entries.TryGetValue(existingKey, out var existingNode))
+            {
+                existingNode.Value.Analysis.Pinned = false;
+                existingNode.Value.Analysis.SnapshotName = "";
+            }
+
+            _entryKeysByName.Remove(name);
+        }
+
+        private void EnsureCacheCanAcceptNewEntry(bool pin, string name, bool replace)
+        {
+            if (_entries.Count < Capacity)
+                return;
+
+            if (_lru.Any(entry => !entry.Analysis.Pinned))
+                return;
+
+            if (pin && replace && _entryKeysByName.ContainsKey(name))
+                return;
+
+            var reason = pin
+                ? "Cannot load named memory snapshot because all cache slots are pinned."
+                : "Cannot analyze memory snapshot because all cache slots are pinned.";
+            throw new CommandFailedException($"{reason} Use MemorySnapshot.Unload to release one.", null);
+        }
+
+        private void EvictIfNeeded()
+        {
+            while (_lru.Count > Capacity)
+            {
+                var last = _lru.Last;
+                while (last != null && last.Value.Analysis.Pinned)
+                    last = last.Previous;
+
+                if (last == null)
+                    throw new CommandFailedException("MemorySnapshot cache is full of pinned entries. Use MemorySnapshot.Unload to release one.", null);
+
+                RemoveNode(last);
+            }
+        }
+
+        private void RemoveNode(LinkedListNode<CacheEntry> node)
+        {
+            _entries.Remove(node.Value.Key);
+            _entryKeysById.Remove(node.Value.Analysis.SnapshotId);
+            if (_entryKeysByName.TryGetValue(node.Value.Analysis.SnapshotName, out var key) &&
+                string.Equals(key, node.Value.Key, StringComparison.Ordinal))
+            {
+                _entryKeysByName.Remove(node.Value.Analysis.SnapshotName);
+            }
+
+            _lru.Remove(node);
+        }
+
+        public MemorySnapshotStatusEntry ToStatusEntry(SnapshotAnalysis analysis)
+        {
+            return new MemorySnapshotStatusEntry
+            {
+                id = analysis.SnapshotId,
+                name = analysis.SnapshotName,
+                pinned = analysis.Pinned,
+                path = analysis.Path,
+                fileSize = analysis.FileSize,
+                analyzedAtUtc = analysis.AnalyzedAtUtc,
+                lastAccessedAtUtc = analysis.LastAccessedAtUtc,
+                analysisMs = analysis.AnalysisMs
+            };
+        }
+
+        private static string ResolveName(string name, FileInfo fileInfo)
+        {
+            return string.IsNullOrWhiteSpace(name) ? GetDefaultName(fileInfo.FullName) : name.Trim();
+        }
+
+        private static string GetDefaultName(string path)
+        {
+            return Path.GetFileNameWithoutExtension(path) ?? "";
+        }
+
+        private static string MakeKey(FileInfo fileInfo)
+        {
+            return fileInfo.FullName + "|" + fileInfo.LastWriteTimeUtc.Ticks;
+        }
+
+        private static string MakeId(string key)
+        {
+            const ulong offset = 14695981039346656037UL;
+            const ulong prime = 1099511628211UL;
+
+            unchecked
+            {
+                var hash = offset;
+                foreach (var ch in key)
+                {
+                    hash ^= ch;
+                    hash *= prime;
+                }
+
+                return "ms_" + hash.ToString("x16");
+            }
+        }
+
+        private sealed class CacheEntry
+        {
+            public readonly string Key;
+            public readonly SnapshotAnalysis Analysis;
+
+            public CacheEntry(string key, SnapshotAnalysis analysis)
+            {
+                Key = key;
+                Analysis = analysis;
+            }
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysisCache.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysisCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7600efef257f24057994df730ab1c47c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99c3a1a2c22bf4c63a77bc285f954d82
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs
@@ -1,0 +1,378 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using UniCli.Server.Editor.Handlers;
+
+namespace UniCli.Server.Editor.MemorySnapshot.Tests
+{
+    public sealed class MemorySnapshotAnalysisQueriesTests
+    {
+        [Test]
+        public void Unit_NativeObjectRetainer_PerTypeObjectsBelowGlobalTop_RetainsPerTypeTopObjects()
+        {
+            var retainer = new NativeObjectRetainer(globalCapacity: 2, perTypeCapacity: 2);
+            retainer.Add(ObjectInfo(1, "Mesh", "huge-a", 1000));
+            retainer.Add(ObjectInfo(2, "Mesh", "huge-b", 900));
+            retainer.Add(ObjectInfo(3, "Texture2D", "small-a", 30));
+            retainer.Add(ObjectInfo(4, "Texture2D", "small-b", 20));
+            retainer.Add(ObjectInfo(5, "Texture2D", "small-c", 10));
+
+            var retained = retainer.Build();
+
+            CollectionAssert.AreEquivalent(new[] { 1L, 2L, 3L, 4L }, retained.Select(item => item.NativeObjectIndex));
+        }
+
+        [Test]
+        public void Unit_GetTopObjects_TypeFilterHasMoreObjectsThanRetained_MarksTruncated()
+        {
+            var analysis = new SnapshotAnalysis
+            {
+                NativeObjectCount = 3,
+                NativeTypeStats = new[]
+                {
+                    TypeStat("Texture2D", count: 3, totalSize: 60)
+                },
+                TopNativeObjects = new[]
+                {
+                    ObjectInfo(1, "Texture2D", "tex-a", 30),
+                    ObjectInfo(2, "Texture2D", "tex-b", 20)
+                }
+            };
+
+            var objects = MemorySnapshotAnalysisQueries.GetTopObjects(
+                analysis,
+                typeFilter: "Texture",
+                nameFilter: "",
+                limit: 20,
+                out var truncated);
+
+            Assert.AreEqual(2, objects.Length);
+            Assert.IsTrue(truncated);
+        }
+
+        [Test]
+        public void Unit_GetTopTypes_FilteredTypes_SortsByTotalSize()
+        {
+            var analysis = new SnapshotAnalysis
+            {
+                NativeTypeStats = new[]
+                {
+                    TypeStat("Texture2D", count: 2, totalSize: 20),
+                    TypeStat("RenderTexture", count: 1, totalSize: 50),
+                    TypeStat("Mesh", count: 4, totalSize: 100)
+                },
+                TopNativeObjects = new RetainedNativeObjectInfo[0]
+            };
+
+            var types = MemorySnapshotAnalysisQueries.GetTopTypes(
+                analysis,
+                typeFilter: "Texture",
+                limit: 20);
+
+            Assert.AreEqual(new[] { "RenderTexture", "Texture2D" }, types.Select(type => type.typeName).ToArray());
+        }
+
+        [Test]
+        public void Unit_GetTopTypes_LimitAndMinSize_RollsUpHiddenTypes()
+        {
+            var analysis = Analysis(
+                TypeStat("Texture2D", count: 2, totalSize: 100),
+                TypeStat("Mesh", count: 4, totalSize: 80),
+                TypeStat("AudioClip", count: 3, totalSize: 10));
+
+            var result = MemorySnapshotAnalysisQueries.GetTopTypes(
+                analysis,
+                MemorySnapshotScope.Native,
+                typeFilter: "",
+                limit: 1,
+                minSize: 20);
+
+            Assert.AreEqual(new[] { "Texture2D" }, result.Types.Select(type => type.typeName).ToArray());
+            Assert.AreEqual(2, result.OthersCount);
+            Assert.AreEqual(90, result.OthersSize);
+        }
+
+        [Test]
+        public void Unit_GetTopTypes_ManagedScope_UsesManagedTypeStats()
+        {
+            var analysis = new SnapshotAnalysis
+            {
+                NativeTypeStats = new[]
+                {
+                    TypeStat("Texture2D", count: 2, totalSize: 100)
+                },
+                ManagedTypeStats = new[]
+                {
+                    TypeStat("System.String", count: 5, totalSize: 50),
+                    TypeStat("Game.Inventory", count: 1, totalSize: 80)
+                },
+                TopNativeObjects = new RetainedNativeObjectInfo[0]
+            };
+
+            var result = MemorySnapshotAnalysisQueries.GetTopTypes(
+                analysis,
+                MemorySnapshotScope.Managed,
+                typeFilter: "",
+                limit: 20,
+                minSize: 0);
+
+            Assert.AreEqual(new[] { "Game.Inventory", "System.String" }, result.Types.Select(type => type.typeName).ToArray());
+        }
+
+        [Test]
+        public void Unit_GetDiffTypes_MixedDeltas_SortsByAbsoluteSizeDelta()
+        {
+            var before = Analysis(
+                TypeStat("Texture2D", count: 10, totalSize: 100),
+                TypeStat("Mesh", count: 4, totalSize: 80),
+                TypeStat("AudioClip", count: 2, totalSize: 50));
+            var after = Analysis(
+                TypeStat("Texture2D", count: 12, totalSize: 130),
+                TypeStat("Mesh", count: 4, totalSize: 70),
+                TypeStat("AudioClip", count: 2, totalSize: 50));
+
+            var diff = MemorySnapshotAnalysisQueries.GetDiffTypes(
+                before,
+                after,
+                typeFilter: "",
+                limit: 20);
+
+            Assert.AreEqual(new[] { "Texture2D", "Mesh" }, diff.Select(type => type.typeName).ToArray());
+            Assert.AreEqual(30, diff[0].sizeDelta);
+            Assert.AreEqual(-10, diff[1].sizeDelta);
+        }
+
+        [Test]
+        public void Unit_GetDiffTypes_MinSizeDelta_RollsUpHiddenDeltas()
+        {
+            var before = Analysis(
+                TypeStat("Texture2D", count: 10, totalSize: 100),
+                TypeStat("Mesh", count: 4, totalSize: 80),
+                TypeStat("AudioClip", count: 2, totalSize: 50),
+                TypeStat("Shader", count: 1, totalSize: 10));
+            var after = Analysis(
+                TypeStat("Texture2D", count: 12, totalSize: 150),
+                TypeStat("Mesh", count: 5, totalSize: 100),
+                TypeStat("AudioClip", count: 2, totalSize: 55),
+                TypeStat("Shader", count: 1, totalSize: 10));
+
+            var result = MemorySnapshotAnalysisQueries.GetDiffTypes(
+                before,
+                after,
+                MemorySnapshotScope.Native,
+                typeFilter: "",
+                limit: 1,
+                minSizeDelta: 10);
+
+            Assert.AreEqual(new[] { "Texture2D" }, result.Types.Select(type => type.typeName).ToArray());
+            Assert.AreEqual(2, result.OthersCount);
+            Assert.AreEqual(25, result.OthersSize);
+        }
+
+        [Test]
+        public void Unit_ResolveDefaultSnapshot_SelectsLatestAndSecondLatestByMtime()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "unicli-memorysnapshot-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try
+            {
+                var oldest = Path.Combine(directory, "oldest.snap");
+                var second = Path.Combine(directory, "second.snap");
+                var latest = Path.Combine(directory, "latest.snap");
+                File.WriteAllText(oldest, "");
+                File.WriteAllText(second, "");
+                File.WriteAllText(latest, "");
+
+                File.SetLastWriteTimeUtc(oldest, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+                File.SetLastWriteTimeUtc(second, new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+                File.SetLastWriteTimeUtc(latest, new DateTime(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+
+                Assert.AreEqual(latest, MemorySnapshotPathResolver.ResolveDefaultSnapshot(directory, 0));
+                Assert.AreEqual(second, MemorySnapshotPathResolver.ResolveDefaultSnapshot(directory, 1));
+            }
+            finally
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void Unit_SnapshotAnalysisCache_LoadOrAnalyze_AssignsNameAndResolvesLoadedSnapshot()
+        {
+            var path = CreateTempSnapshotPath();
+
+            try
+            {
+                var cache = new SnapshotAnalysisCache();
+                var analyzer = new FakeSnapshotAnalyzer();
+                var analysis = cache.LoadOrAnalyze(
+                    path,
+                    analyzer,
+                    "before",
+                    replace: false,
+                    out var cached,
+                    out _,
+                    out var entry);
+
+                Assert.IsFalse(cached);
+                Assert.AreEqual(1, analyzer.AnalyzeCount);
+                Assert.AreEqual("before", entry.name);
+                Assert.IsTrue(entry.pinned);
+                StringAssert.StartsWith("ms_", entry.id);
+
+                var loadedByName = cache.GetLoaded("before", out var byNameEntry);
+                var loadedById = cache.GetLoaded(entry.id, out var byIdEntry);
+
+                Assert.AreSame(analysis, loadedByName);
+                Assert.AreSame(analysis, loadedById);
+                Assert.AreEqual(entry.id, byNameEntry.id);
+                Assert.AreEqual("before", byIdEntry.name);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void Unit_SnapshotAnalysisCache_LoadOrAnalyze_NameCollisionRequiresReplace()
+        {
+            var firstPath = CreateTempSnapshotPath();
+            var secondPath = CreateTempSnapshotPath();
+
+            try
+            {
+                var cache = new SnapshotAnalysisCache();
+                var analyzer = new FakeSnapshotAnalyzer();
+                cache.LoadOrAnalyze(firstPath, analyzer, "focus", replace: false, out _, out _, out var firstEntry);
+
+                Assert.Throws<CommandFailedException>(() =>
+                    cache.LoadOrAnalyze(secondPath, analyzer, "focus", replace: false, out _, out _, out _));
+
+                cache.LoadOrAnalyze(secondPath, analyzer, "focus", replace: true, out _, out _, out var replacedEntry);
+                var loaded = cache.GetLoaded("focus", out var loadedEntry);
+
+                Assert.AreEqual(secondPath, loaded.Path);
+                Assert.AreEqual(replacedEntry.id, loadedEntry.id);
+                Assert.AreNotEqual(firstEntry.id, loadedEntry.id);
+            }
+            finally
+            {
+                File.Delete(firstPath);
+                File.Delete(secondPath);
+            }
+        }
+
+        [Test]
+        public void Unit_SnapshotAnalysisCache_Remove_Name_ReleasesLoadedSnapshot()
+        {
+            var path = CreateTempSnapshotPath();
+
+            try
+            {
+                var cache = new SnapshotAnalysisCache();
+                var analyzer = new FakeSnapshotAnalyzer();
+                cache.LoadOrAnalyze(path, analyzer, "release-me", replace: false, out _, out _, out _);
+
+                Assert.AreEqual(1, cache.Remove("release-me"));
+                Assert.AreEqual(0, cache.Remove("release-me"));
+                Assert.Throws<CommandFailedException>(() => cache.GetLoaded("release-me", out _));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void Unit_AllOfMemoryRequest_Defaults_KeepsObjectRowsOptIn()
+        {
+            var request = new MemorySnapshotAllOfMemoryRequest();
+
+            Assert.AreEqual(20, request.limit);
+            Assert.IsTrue(request.includeCategories);
+            Assert.IsTrue(request.includeNativeTypes);
+            Assert.IsTrue(request.includeManagedTypes);
+            Assert.IsFalse(request.includeNativeObjects);
+            Assert.IsTrue(request.includeDiff);
+        }
+
+        [Test]
+        public void Unit_AllOfMemoryScopeParser_VariousInputs_ReturnsExpected()
+        {
+            Assert.AreEqual(MemorySnapshotAllOfMemoryScope.All, MemorySnapshotAllOfMemoryScopeParser.Parse(""));
+            Assert.AreEqual(MemorySnapshotAllOfMemoryScope.All, MemorySnapshotAllOfMemoryScopeParser.Parse("all"));
+            Assert.AreEqual(MemorySnapshotAllOfMemoryScope.Native, MemorySnapshotAllOfMemoryScopeParser.Parse("native"));
+            Assert.AreEqual(MemorySnapshotAllOfMemoryScope.Managed, MemorySnapshotAllOfMemoryScopeParser.Parse("managed"));
+            Assert.Throws<CommandFailedException>(() => MemorySnapshotAllOfMemoryScopeParser.Parse("objects"));
+        }
+
+        private static SnapshotAnalysis Analysis(params MemorySnapshotNativeTypeStat[] typeStats)
+        {
+            return new SnapshotAnalysis
+            {
+                NativeTypeStats = typeStats,
+                ManagedTypeStats = new MemorySnapshotNativeTypeStat[0],
+                TopNativeObjects = new RetainedNativeObjectInfo[0]
+            };
+        }
+
+        private static MemorySnapshotNativeTypeStat TypeStat(string typeName, long count, long totalSize)
+        {
+            return new MemorySnapshotNativeTypeStat
+            {
+                typeName = typeName,
+                count = count,
+                totalSize = totalSize
+            };
+        }
+
+        private static RetainedNativeObjectInfo ObjectInfo(long index, string typeName, string name, long size)
+        {
+            return new RetainedNativeObjectInfo
+            {
+                NativeObjectIndex = index,
+                TypeName = typeName,
+                Name = name,
+                Size = size,
+                InstanceId = index.ToString()
+            };
+        }
+
+        private static string CreateTempSnapshotPath()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "unicli-memorysnapshot-" + Guid.NewGuid().ToString("N") + ".snap");
+            File.WriteAllText(path, "");
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+            return path;
+        }
+
+        private sealed class FakeSnapshotAnalyzer : ISnapshotAnalyzer
+        {
+            public int AnalyzeCount { get; private set; }
+
+            public bool IsAvailable(out string unavailableReason)
+            {
+                unavailableReason = "";
+                return true;
+            }
+
+            public SnapshotAnalysis Analyze(string snapshotPath)
+            {
+                AnalyzeCount++;
+                return new SnapshotAnalysis
+                {
+                    Metadata = new MemorySnapshotMetadataInfo(),
+                    Categories = new MemorySnapshotCategoryInfo[0],
+                    NativeTypeStats = new MemorySnapshotNativeTypeStat[0],
+                    ManagedTypeStats = new MemorySnapshotNativeTypeStat[0],
+                    TopNativeObjects = new RetainedNativeObjectInfo[0]
+                };
+            }
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af3aabd56461147fbb1d061476b7b052
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/UniCli.Server.Editor.MemorySnapshot.Tests.asmdef
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/UniCli.Server.Editor.MemorySnapshot.Tests.asmdef
@@ -1,0 +1,30 @@
+{
+    "name": "UniCli.Server.Editor.MemorySnapshot.Tests",
+    "rootNamespace": "UniCli.Server.Editor.MemorySnapshot.Tests",
+    "references": [
+        "UniCli.Server.Editor",
+        "UniCli.Server.Editor.MemorySnapshot"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
+        "UNICLI_MEMORY_PROFILER"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.memoryprofiler",
+            "expression": "[1.0.0,2.0.0)",
+            "define": "UNICLI_MEMORY_PROFILER"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/UniCli.Server.Editor.MemorySnapshot.Tests.asmdef.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/UniCli.Server.Editor.MemorySnapshot.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38c432c4af8cd4ea4adab08b33bc4474
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/UniCli.Server.Editor.MemorySnapshot.asmdef
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/UniCli.Server.Editor.MemorySnapshot.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "UniCli.Server.Editor.MemorySnapshot",
+    "rootNamespace": "UniCli.Server.Editor.Handlers.MemorySnapshot",
+    "references": [
+        "UniCli.Server.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNICLI_MEMORY_PROFILER"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.memoryprofiler",
+            "expression": "[1.0.0,2.0.0)",
+            "define": "UNICLI_MEMORY_PROFILER"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/UniCli.Server.Editor.MemorySnapshot.asmdef.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/UniCli.Server.Editor.MemorySnapshot.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: baeea0e2666034564845ea959610e4d7
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Profiler/ProfilerTakeSnapshotHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Profiler/ProfilerTakeSnapshotHandler.cs
@@ -10,7 +10,7 @@ namespace UniCli.Server.Editor.Handlers
     public sealed class ProfilerTakeSnapshotHandler : CommandHandler<ProfilerTakeSnapshotRequest, ProfilerTakeSnapshotResponse>
     {
         public override string CommandName => "Profiler.TakeSnapshot";
-        public override string Description => "Take a memory snapshot (.snap file)";
+        public override string Description => "Take a memory snapshot (.snap file); use MemorySnapshot.Capture when the optional MemorySnapshot command family is available";
 
         protected override bool TryWriteFormatted(ProfilerTakeSnapshotResponse response, bool success, IFormatWriter writer)
         {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/ModuleRegistry.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Modules/ModuleRegistry.cs
@@ -16,6 +16,7 @@ namespace UniCli.Server.Editor
             new ModuleDefinition("Remote", "Remote debug and Connection operations"),
 
             new ModuleDefinition("Recorder", "Video recording operations (requires com.unity.recorder)"),
+            new ModuleDefinition("MemoryProfiler", "Memory snapshot analysis operations (requires com.unity.memoryprofiler)"),
             new ModuleDefinition("Search", "Unity Search API operations"),
             new ModuleDefinition("NuGet", "NuGet package management (requires NuGetForUnity)"),
             new ModuleDefinition("BuildMagic", "BuildMagic build scheme operations (requires jp.co.cyberagent.buildmagic)"),

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServiceRegistry.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/ServiceRegistry.cs
@@ -58,7 +58,8 @@ namespace UniCli.Server.Editor
 
         public object CreateInstance(Type type)
         {
-            var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(c => c.IsPublic || c.IsAssembly)
                 .OrderBy(c => c.GetParameters().Length)
                 .ToArray();
 
@@ -81,7 +82,7 @@ namespace UniCli.Server.Editor
 
                 if (canResolve)
                 {
-                    return Activator.CreateInstance(type, args);
+                    return ctor.Invoke(args);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add optional MemorySnapshot commands for listing, capturing, loading, status, summary, diff, top-object, and all-of-memory analysis.
- Back the commands with a named LRU snapshot analysis cache so repeated comparisons can reuse loaded snapshots.
- Gate the MemorySnapshot assembly to `com.unity.memoryprofiler` 1.x and document usage in README / skill guidance.

## Impact
- Adds a MemoryProfiler-specific asmdef that only compiles when MemoryProfiler 1.x is installed.
- Registers the snapshot cache and analyzer through `ServiceRegistry`, including internal constructor resolution for handlers.
- Keeps `Profiler.TakeSnapshot` available while pointing users to the MemorySnapshot command family when the optional package is installed.
- Removes custom formatted output overrides from MemorySnapshot commands; responses use JSON output.

## Test
- `dotnet build src/UniCli.Unity/UniCli.Server.Editor.csproj -v:minimal` → success with existing Unity reference / obsolete warnings.
- `dotnet build src/UniCli.Unity/UniCli.Server.Editor.Tests.csproj -v:minimal` → success with existing warnings.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 2` existing obsolete warnings.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --json` → `75 passed`, `0 failed`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli commands --json | rg 'MemorySnapshot\.'` → MemorySnapshot commands registered.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Status --json` → success, empty cache, capacity `8`.
- `git diff --check origin/main...HEAD` → success.

## Open items
