### PR TITLE
Add Editor.Status command

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -27,6 +27,8 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 6. **When running tests**: Always use the default `--resultFilter failures` (or `--resultFilter none` for summary-only) to keep output minimal. Only use `--resultFilter all` when you specifically need to inspect individual passed test details. This prevents large test suites from flooding context. Stack traces are omitted by default (`--stackTraceLines 0`); use `--stackTraceLines 3` when you need to diagnose a failure location.
 7. **When checking console logs**: Use `Console.GetLog` with `{"logType":"Warning,Error"}` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `{"logType":"Error","stackTraceLines":3}` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. `--help` includes nested type details when applicable, and `commands --json` provides nested schemas via each command's `requestTypeDetails` and `responseTypeDetails`. Match nested type details by `typeId`; `type` and `typeName` are display labels and may not be unique. Do not rely on memorized command lists — the project may have custom commands.
+9. **Before scene-affecting operations**: Run `unicli exec Editor.Status` (without `--json` — the compact text summary is enough to check for dirty state and keeps output small) before `TestRunner.RunPlayMode`, `BuildPlayer.Build`, `Scene.Open`, `Scene.New`, `Scene.Close`, `Menu.Execute`, or entering Play Mode. `TestRunner.RunPlayMode` is the most common offender: the test runner creates a temporary test scene and swaps out the currently open scenes, so any unsaved scene changes at that moment can trigger a save prompt, abort the run, or leave the CLI waiting forever. If dirty scenes came from your own edits, save only the changes that should persist; revert or discard temporary probe changes when that is safer. If the dirty state may be from the user, do not save or discard it; ask the user how to proceed.
+10. **When commands hang or time out**: Suspect a Unity Editor modal dialog such as a scene save prompt. Do not keep retrying blindly; ask the user to close or resolve the dialog, then retry.
 
 ## Project Path
 
@@ -94,6 +96,15 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 - `--help` — Show command parameters and nested type details
 
 ## Key Workflows
+
+**Pre-flight before scene-affecting commands:**
+
+```bash
+unicli exec Editor.Status
+# Save only when the dirty scenes are your own intended persistent changes.
+unicli exec Scene.Save '{"all":true}' --json
+unicli exec TestRunner.RunPlayMode --json
+```
 
 **Compile and run tests:**
 

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -30,6 +30,8 @@ The CLI (`unicli`) communicates with the Unity Editor over named pipes, so the E
 6. **When running tests**: Always use the default `--resultFilter failures` (or `--resultFilter none` for summary-only) to keep output minimal. Only use `--resultFilter all` when you specifically need to inspect individual passed test details. This prevents large test suites from flooding context. Stack traces are omitted by default (`--stackTraceLines 0`); use `--stackTraceLines 3` when you need to diagnose a failure location.
 7. **When checking console logs**: Use `Console.GetLog` with `{"logType":"Warning,Error"}` to filter out informational noise and focus on actionable issues. Stack traces are omitted by default; use `{"logType":"Error","stackTraceLines":3}` when debugging errors.
 8. **Discover commands dynamically**: Use `unicli commands --json` to list all available commands and `unicli exec <command> --help` to see parameters for any command. Do not rely on memorized command lists — the project may have custom commands.
+9. **Before scene-affecting operations**: Run `unicli exec Editor.Status` (without `--json` — the compact text summary is enough to check for dirty state and keeps output small) before `TestRunner.RunPlayMode`, `BuildPlayer.Build`, `Scene.Open`, `Scene.New`, `Scene.Close`, `Menu.Execute`, or entering Play Mode. `TestRunner.RunPlayMode` is the most common offender: the test runner creates a temporary test scene and swaps out the currently open scenes, so any unsaved scene changes at that moment can trigger a save prompt, abort the run, or leave the CLI waiting forever. If dirty scenes came from your own edits, save only the changes that should persist; revert or discard temporary probe changes when that is safer. If the dirty state may be from the user, do not save or discard it; ask the user how to proceed.
+10. **When commands hang or time out**: Suspect a Unity Editor modal dialog such as a scene save prompt. Do not keep retrying blindly; ask the user to close or resolve the dialog, then retry.
 
 ## Project Path
 
@@ -97,6 +99,15 @@ unicli exec BuildPlayer.Build --locationPathName "Builds/Test.app" --options Dev
 - `--help` — Show command parameters and usage
 
 ## Key Workflows
+
+**Pre-flight before scene-affecting commands:**
+
+```bash
+unicli exec Editor.Status
+# Save only when the dirty scenes are your own intended persistent changes.
+unicli exec Scene.Save '{"all":true}' --json
+unicli exec TestRunner.RunPlayMode --json
+```
 
 **Compile and run tests:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ dotnet build src/UniCli.Client
 # Publish Client and test with the built binary
 dotnet publish src/UniCli.Client -o .build
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli commands --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Editor.Status --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json
 
 # GameObject operations

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ unicli exec GameObject.AddComponent --path "Enemy" --typeName BoxCollider
 unicli exec Scene.Open --path "Assets/Scenes/Level1.unity"
 unicli exec Scene.Save --all
 
+# Pre-flight before commands that can trigger scene-save dialogs (text output is compact)
+unicli exec Editor.Status
+# Save only when the dirty scenes are your own intended persistent changes.
+unicli exec Scene.Save '{"all":true}' --json
+unicli exec TestRunner.RunPlayMode --json
+
 # Set component properties
 unicli exec Component.SetProperty --componentInstanceId 1234 --propertyPath "m_IsKinematic" --value "true"
 
@@ -456,6 +462,7 @@ The following commands are built in. Run `unicli commands` to see this list from
 | Command | Description |
 |---|---|
 | `Compile` | Compile scripts and return results |
+| `Editor.Status` | Get EditorApplication, EditorSceneManager, SceneManager, and PrefabStageUtility status |
 | `Eval` | Compile and execute C# code dynamically |
 
 ### Console

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EditorStatusHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EditorStatusHandler.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UniCli.Protocol;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    public sealed class EditorStatusHandler : CommandHandler<Unit, EditorStatusResponse>
+    {
+        public override string CommandName => "Editor.Status";
+        public override string Description => "Get Unity Editor status via EditorApplication, EditorSceneManager, SceneManager, and PrefabStageUtility";
+
+        protected override bool TryWriteFormatted(EditorStatusResponse response, bool success, IFormatWriter writer)
+        {
+            if (!success)
+                return false;
+
+            writer.WriteLine($"Playing: {response.isPlaying}, Paused: {response.isPaused}, WillChangePlaymode: {response.willChangePlaymode}");
+            writer.WriteLine($"Compiling: {response.isCompiling}, Updating: {response.isUpdating}");
+            writer.WriteLine($"Dirty scenes: {(response.hasDirtyScenes ? "Yes" : "No")}, Untitled scene: {(response.hasUntitledScene ? "Yes" : "No")}");
+
+            if (response.dirtyScenes != null)
+            {
+                foreach (var scene in response.dirtyScenes)
+                {
+                    var path = string.IsNullOrEmpty(scene.path) ? "(untitled)" : scene.path;
+                    writer.WriteLine($"  {scene.name} ({path}) buildIndex={scene.buildIndex} rootCount={scene.rootCount}");
+                }
+            }
+
+            if (response.prefabStageOpen)
+                writer.WriteLine($"Prefab stage: {response.prefabStageAssetPath} dirty={response.prefabStageDirty}");
+            else
+                writer.WriteLine("Prefab stage: closed");
+
+            return true;
+        }
+
+        protected override ValueTask<EditorStatusResponse> ExecuteAsync(Unit request, CancellationToken cancellationToken)
+        {
+            var dirtyScenes = new List<SceneInfo>();
+            var hasUntitledScene = false;
+
+            for (var i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                if (string.IsNullOrEmpty(scene.path))
+                    hasUntitledScene = true;
+
+                if (!scene.isDirty)
+                    continue;
+
+                dirtyScenes.Add(new SceneInfo
+                {
+                    name = scene.name,
+                    path = scene.path,
+                    buildIndex = scene.buildIndex,
+                    isDirty = scene.isDirty,
+                    isLoaded = scene.isLoaded,
+                    rootCount = scene.rootCount
+                });
+            }
+
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            var prefabStageOpen = prefabStage != null;
+
+            return new ValueTask<EditorStatusResponse>(new EditorStatusResponse
+            {
+                isPlaying = EditorApplication.isPlaying,
+                isPaused = EditorApplication.isPaused,
+                willChangePlaymode = EditorApplication.isPlayingOrWillChangePlaymode,
+                isCompiling = EditorApplication.isCompiling,
+                isUpdating = EditorApplication.isUpdating,
+                hasDirtyScenes = dirtyScenes.Count > 0,
+                hasUntitledScene = hasUntitledScene,
+                dirtyScenes = dirtyScenes.ToArray(),
+                prefabStageOpen = prefabStageOpen,
+                prefabStageAssetPath = prefabStageOpen ? prefabStage.assetPath ?? "" : "",
+                prefabStageDirty = prefabStageOpen && prefabStage.scene.isDirty
+            });
+        }
+    }
+
+    [Serializable]
+    public class EditorStatusResponse
+    {
+        public bool isPlaying;
+        public bool isPaused;
+        public bool willChangePlaymode;
+        public bool isCompiling;
+        public bool isUpdating;
+        public bool hasDirtyScenes;
+        public bool hasUntitledScene;
+        public SceneInfo[] dirtyScenes;
+        public bool prefabStageOpen;
+        public string prefabStageAssetPath;
+        public bool prefabStageDirty;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EditorStatusHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/EditorStatusHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e544ce17729b40798e59844c7483af6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add `Editor.Status` to report Unity Editor play mode, compile/update, dirty scene, untitled scene, and prefab stage status.
- Document `Editor.Status` as a pre-flight check before scene-affecting commands that can trigger Unity scene-save prompts.
- Update UniCli skill guidance to stop on user-owned dirty scenes and avoid blind retries when a Unity modal dialog blocks the CLI.

## Impact
- Adds a core command that is always available without optional package dependencies.
- Helps agents and users detect dirty scenes before `TestRunner.RunPlayMode`, `Scene.Open`, `Scene.New`, `Scene.Close`, `Menu.Execute`, build, or Play Mode transitions.
- Does not change existing scene commands; risky commands still need caller-side pre-flight handling.
- README / CLAUDE / skill docs now recommend compact text output for human pre-flight checks and JSON output for structured parsing.

## Test
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import '{"path":"Packages/com.yucchiy.unicli-server/Editor/Handlers/EditorStatusHandler.cs"}' --json` → success.
- `dotnet build src/UniCli.Unity/UniCli.Server.Editor.csproj -v:minimal` → success with existing Unity reference conflict warnings.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Editor.Status` → compact text output succeeds and reports no dirty scenes.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Editor.Status --json` → success, `hasDirtyScenes: false`, `hasUntitledScene: false`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli commands --json` → `Editor.Status` is registered.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `75 passed`, `0 failed`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --resultFilter none --json` → `total: 0`, `failed: 0` after `Editor.Status` pre-flight.
- Manual verification: dirty scene + `EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()` displayed the Unity `New Scene` save prompt and blocked the CLI until resolved.
- Manual verification: dirty scene + `Editor.Status --json` returned `hasDirtyScenes: true` with `SampleScene`, allowing the risky operation to be skipped.
- `git diff --check` → success.

## Open items
- None.
