### PR TITLE
Release v1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.3.3"
+  version: "1.4.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.3.3</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
### Summary

Prepares the `v1.4.0` minor release.

This release includes the MemorySnapshot analysis command family merged in #146 and the `Editor.Status` pre-flight command merged in #147. It bumps the CLI, Unity package, and Claude plugin metadata versions from `1.3.3` to `1.4.0`.

### Impact

- Updates the CLI package version to `1.4.0`.
- Updates `com.yucchiy.unicli-server` package metadata to `1.4.0`.
- Updates Claude plugin marketplace and skill metadata to `1.4.0`.
- Includes optional MemoryProfiler 1.x-gated MemorySnapshot commands for snapshot listing, loading, summary, diff, top-object, all-of-memory, status, and unload workflows.
- Includes `Editor.Status` for dirty scene / prefab stage / Editor state pre-flight checks before scene-affecting operations.

### Tests

- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import '{"path":"Packages/com.yucchiy.unicli-server/package.json"}' --json` → success.
- `dotnet build src/UniCli.Protocol` → success with existing nullable warnings.
- `dotnet publish src/UniCli.Client -o .build` → success with existing nullable / AOT warnings.
- `.build/unicli --version` → `1.4.0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Editor.Status --json` → success, no dirty scenes.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `75 passed`, `0 failed`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunPlayMode --resultFilter none --json` → `total: 0`, `failed: 0` after `Editor.Status` pre-flight.
- `git diff --check` → success.

### Unresolved

- After this PR is merged, create and push the release tag: `git tag v1.4.0 && git push origin v1.4.0`.
