### PR TITLE
Extend MemorySnapshot AllOfMemory filters

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -5,11 +5,11 @@ description: >-
   available: running `unicli exec`/`unicli eval`, editing files under `Assets/`
   or `Packages/`, compiling Unity code, running EditMode/PlayMode tests, and
   creating or modifying GameObjects, scenes, prefabs, assets, packages, build
-  settings, or project settings. Follow required safeguards such as
+  settings, project settings, or memory snapshots. Follow required safeguards such as
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.3.2"
+  version: "1.4.0"
 ---
 
 # UniCli — Unity Editor CLI
@@ -169,6 +169,35 @@ unicli exec Remote.Invoke '{"command":"Debug.GetPlayerPref","data":"{\"key\":\"H
 ```
 
 Built-in debug commands: `Debug.SystemInfo`, `Debug.Stats`, `Debug.GetLogs`, `Debug.GetHierarchy`, `Debug.FindGameObjects`, `Debug.GetScenes`, `Debug.GetPlayerPref`
+
+**Investigate a memory leak:**
+
+`MemorySnapshot.*` commands are available when the project has `com.unity.memoryprofiler`. Captures can come from `MemorySnapshot.Capture`, `Profiler.TakeSnapshot`, or the Memory Profiler window; commands read `.snap` paths or named loaded snapshots and keep heavy snapshot data out of the CLI response.
+
+```bash
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/before.snap"}' --json
+# Reproduce the suspected leak in Play Mode or a connected player.
+unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/after.snap"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"before"}' --json
+unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","includeBreakdownTree":true,"pathFilter":"Native/Unity Subsystems","pathDepth":1,"memoryMetric":"both"}' --json
+unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"native","minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","typeFilter":"Texture2D","limit":20}' --json
+unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":20}' --json
+unicli exec MemorySnapshot.Analyze '{"snapshot":"after","baseSnapshot":"before","limit":10}' --json
+```
+
+Useful MemorySnapshot commands:
+
+- `MemorySnapshot.Capture` — capture a `.snap` file; optional `flags` are `Unity.Profiling.Memory.CaptureFlags` names.
+- `MemorySnapshot.List` / `MemorySnapshot.Load` — list files, then pin a snapshot under a stable `name`/`id`.
+- `MemorySnapshot.Status` / `MemorySnapshot.Unload` — inspect loaded/cached analyses, release one by id/name, or clear all cached entries.
+- `MemorySnapshot.Summary` — category totals and metadata; use `snapshot` or `path`, omitted `path` uses the latest `MemoryCaptures/*.snap`.
+- `MemorySnapshot.AllOfMemory` — Memory Profiler All Of Memory style report; default is bounded type sections. Use `includeBreakdownTree`/`pathFilter`/`pathDepth` for All Of Memory tree paths, and `memoryMetric` (`allocated`, `resident`, `both`) for tree sorting and `minSize`; type/object sections remain allocated-based.
+- `MemorySnapshot.TopObjects` — largest native objects or native/managed type totals; use `scope:"managed"` for managed type aggregation.
+- `MemorySnapshot.Diff` — native/managed type deltas; use `baseSnapshot`/`targetSnapshot` or paths, omitted paths use latest and second latest snapshots.
+- `MemorySnapshot.Analyze` — compact one-shot report combining summary, top types/objects, and optional diff.
 
 ## Custom Command Handlers
 

--- a/.agents/skills/unity-development/agents/openai.yaml
+++ b/.agents/skills/unity-development/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "UniCli — Unity Editor CLI"
-  short_description: "Control Unity Editor from the terminal via UniCli CLI"
-  default_prompt: "Use $unity-development to compile Unity scripts and run tests via UniCli."
+  short_description: "Control Unity Editor and memory snapshots via UniCli CLI"
+  default_prompt: "Use $unity-development to automate Unity Editor with UniCli, compile scripts, run tests, and inspect memory snapshots."
 
 policy:
   allow_implicit_invocation: true

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -184,6 +184,7 @@ unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/after.snap"}' --json
 unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"before"}' --json
 unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
 unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","includeBreakdownTree":true,"pathFilter":"Native/Unity Subsystems","pathDepth":1,"memoryMetric":"both"}' --json
 unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"native","minSizeDelta":1048576}' --json
 unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","typeFilter":"Texture2D","limit":20}' --json
 unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":20}' --json
@@ -196,7 +197,7 @@ Useful MemorySnapshot commands:
 - `MemorySnapshot.List` / `MemorySnapshot.Load` — list files, then pin a snapshot under a stable `name`/`id`.
 - `MemorySnapshot.Status` / `MemorySnapshot.Unload` — inspect loaded/cached analyses, release one by id/name, or clear all cached entries.
 - `MemorySnapshot.Summary` — category totals and metadata; use `snapshot` or `path`, omitted `path` uses the latest `MemoryCaptures/*.snap`.
-- `MemorySnapshot.AllOfMemory` — Memory Profiler All Of Memory style report; default is bounded type sections, use `limit`, `scope`, `typeFilter`, `nameFilter`, `minSize`, `minSizeDelta`, and `includeNativeObjects` to control output size.
+- `MemorySnapshot.AllOfMemory` — Memory Profiler All Of Memory style report; default is bounded type sections. Use `includeBreakdownTree`/`pathFilter`/`pathDepth` for All Of Memory tree paths, and `memoryMetric` (`allocated`, `resident`, `both`) for tree sorting and `minSize`; type/object sections remain allocated-based.
 - `MemorySnapshot.TopObjects` — largest native objects or native/managed type totals; use `scope:"managed"` for managed type aggregation.
 - `MemorySnapshot.Diff` — native/managed type deltas; use `baseSnapshot`/`targetSnapshot` or paths, omitted paths use latest and second latest snapshots.
 - `MemorySnapshot.Analyze` — compact one-shot report combining summary, top types/objects, and optional diff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary '{"path":"MemoryCaptures/my_snapshot.snap"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.Summary '{"snapshot":"after"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","includeBreakdownTree":true,"pathFilter":"Native/Unity Subsystems","pathDepth":1,"memoryMetric":"both"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","scope":"managed","typeFilter":"System.","limit":20}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","scope":"native","includeNativeObjects":true,"typeFilter":"Texture2D","nameFilter":"atlas","limit":20}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.TopObjects '{"path":"MemoryCaptures/my_snapshot.snap","groupByType":true}' --json

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/before.snap","name":"be
 unicli exec MemorySnapshot.Capture '{"path":"MemoryCaptures/after.snap"}' --json
 unicli exec MemorySnapshot.Load '{"path":"MemoryCaptures/after.snap","name":"after"}' --json
 unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","baseSnapshot":"before","limit":20,"minSize":1048576,"minSizeDelta":1048576}' --json
+unicli exec MemorySnapshot.AllOfMemory '{"snapshot":"after","includeBreakdownTree":true,"pathFilter":"Native/Unity Subsystems","pathDepth":1,"memoryMetric":"both"}' --json
 unicli exec MemorySnapshot.Diff '{"baseSnapshot":"before","targetSnapshot":"after","scope":"native","minSizeDelta":1048576}' --json
 unicli exec MemorySnapshot.TopObjects '{"snapshot":"after","scope":"managed","groupByType":true,"limit":10}' --json
 unicli exec MemorySnapshot.Analyze '{"snapshot":"after","baseSnapshot":"before","limit":10}' --json
@@ -658,12 +659,14 @@ Requires Unity Memory Profiler (`com.unity.memoryprofiler`). Use `MemorySnapshot
 | `MemorySnapshot.List` | List memory snapshot (.snap) files |
 | `MemorySnapshot.Load` | Analyze and pin a snapshot under a `name`/`id` for later commands |
 | `MemorySnapshot.Summary` | Summarize category totals and metadata; use `snapshot` or `path`, omitted `path` uses the latest `MemoryCaptures/*.snap` |
-| `MemorySnapshot.AllOfMemory` | Show a Memory Profiler All Of Memory style report with `limit`, `scope`, `typeFilter`, `nameFilter`, `minSize`, `minSizeDelta`, and `include*` filters |
+| `MemorySnapshot.AllOfMemory` | Show a Memory Profiler All Of Memory style report with `limit`, `scope`, `typeFilter`, `nameFilter`, `pathFilter`, `pathDepth`, `memoryMetric`, `minSize`, `minSizeDelta`, and `include*` filters |
 | `MemorySnapshot.TopObjects` | List largest retained native objects or native/managed type totals; use `snapshot` or `path` |
 | `MemorySnapshot.Diff` | Compare native or managed type deltas; use `baseSnapshot`/`targetSnapshot` or paths, omitted paths use latest and second latest captures |
 | `MemorySnapshot.Analyze` | Produce a compact summary/top/diff report for leak investigation |
 | `MemorySnapshot.Status` | Show loaded/cached snapshot analyses with id/name/pinned state |
 | `MemorySnapshot.Unload` | Release one loaded snapshot by `snapshot` id/name, or clear cached analysis results |
+
+`MemorySnapshot.AllOfMemory` can return a bounded flat `breakdownTree` with `includeBreakdownTree:true`; `pathFilter` matches root-origin `/` segments exactly and enables the tree implicitly. `memoryMetric` (`allocated`, `resident`, `both`) only affects `breakdownTree` sorting and `minSize`; type/object sections remain allocated-based, and resident falls back to allocated when unavailable.
 
 ### Screenshot / Recorder
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AllTrackedMemoryReflection.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AllTrackedMemoryReflection.cs
@@ -1,0 +1,320 @@
+#if UNICLI_MEMORY_PROFILER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal sealed class AllTrackedMemoryReflection
+    {
+        private const BindingFlags InstanceMembers =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        private const BindingFlags StaticMembers =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+        private static AllTrackedMemoryReflection _cached;
+        private static string _cachedUnavailableReason;
+
+        private readonly ConstructorInfo _builderCtor;
+        private readonly ConstructorInfo _buildArgsCtor;
+        private readonly MethodInfo _build;
+        private readonly PropertyInfo _rootNodes;
+        private readonly PropertyInfo _itemDataName;
+        private readonly PropertyInfo _itemDataSize;
+        private readonly FieldInfo _memorySizeCommitted;
+        private readonly FieldInfo _memorySizeResident;
+        private readonly MemberInfo _treeItemData;
+        private readonly MemberInfo _treeItemChildren;
+        private readonly MemberInfo _treeItemHasChildren;
+
+        private AllTrackedMemoryReflection(Assembly assembly)
+        {
+            var builderType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.UI.AllTrackedMemoryModelBuilder");
+            var modelType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.UI.AllTrackedMemoryModel");
+            var memorySizeType = GetRequiredType(assembly, "Unity.MemoryProfiler.Editor.MemorySize");
+            var itemDataType = GetRequiredNestedType(modelType, "ItemData");
+            var buildArgsType = GetRequiredNestedType(builderType, "BuildArgs");
+
+            _builderCtor = GetRequiredConstructor(builderType, Type.EmptyTypes);
+            _buildArgsCtor = GetRequiredConstructor(buildArgsType, parameterCount: 8);
+            _build = GetRequiredMethod(builderType, "Build", parameterCount: 2);
+            _rootNodes = GetRequiredProperty(modelType, "RootNodes");
+            _itemDataName = GetRequiredProperty(itemDataType, "Name");
+            _itemDataSize = GetRequiredProperty(itemDataType, "Size");
+            _memorySizeCommitted = GetRequiredField(memorySizeType, "Committed");
+            _memorySizeResident = GetRequiredField(memorySizeType, "Resident");
+
+            var treeItemType = _rootNodes.PropertyType.GetGenericArguments()[0];
+            _treeItemData = GetRequiredFieldOrProperty(treeItemType, "data");
+            _treeItemChildren = GetRequiredFieldOrProperty(treeItemType, "children");
+            _treeItemHasChildren = GetRequiredFieldOrProperty(treeItemType, "hasChildren");
+        }
+
+        public static bool TryGet(out AllTrackedMemoryReflection reflection, out string unavailableReason)
+        {
+            if (_cached != null)
+            {
+                reflection = _cached;
+                unavailableReason = "";
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(_cachedUnavailableReason))
+            {
+                reflection = null;
+                unavailableReason = _cachedUnavailableReason;
+                return false;
+            }
+
+            try
+            {
+                var assembly = FindMemoryProfilerAssembly();
+                if (assembly == null)
+                    throw new InvalidOperationException("Assembly Unity.MemoryProfiler.Editor is not loaded.");
+
+                _cached = new AllTrackedMemoryReflection(assembly);
+                reflection = _cached;
+                unavailableReason = "";
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _cachedUnavailableReason = ex.Message;
+                reflection = null;
+                unavailableReason = _cachedUnavailableReason;
+                return false;
+            }
+        }
+
+        public MemorySnapshotBreakdownTreeNode[] BuildBreakdownTree(object snapshot, bool residentAvailable)
+        {
+            var builder = _builderCtor.Invoke(null);
+            var args = _buildArgsCtor.Invoke(new object[]
+            {
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                false,
+                null
+            });
+            var model = _build.Invoke(builder, new[] { snapshot, args });
+            var rootItems = ToObjectList((IEnumerable)_rootNodes.GetValue(model, null));
+            var nodes = new List<MemorySnapshotBreakdownTreeNode>(
+                Math.Min(MemorySnapshotBreakdownTreeLimits.MaxAnalysisNodes, rootItems.Count));
+
+            foreach (var item in SortItemsForRetention(rootItems))
+            {
+                if (nodes.Count >= MemorySnapshotBreakdownTreeLimits.MaxAnalysisNodes)
+                    break;
+
+                AddNode(item, "", 0, residentAvailable, nodes);
+            }
+
+            return nodes.ToArray();
+        }
+
+        private void AddNode(
+            object item,
+            string parentPath,
+            int depth,
+            bool residentAvailable,
+            List<MemorySnapshotBreakdownTreeNode> nodes)
+        {
+            var data = GetValue(_treeItemData, item);
+            var name = _itemDataName.GetValue(data, null) as string ?? "";
+            var size = _itemDataSize.GetValue(data, null);
+            var path = string.IsNullOrEmpty(parentPath) ? name : parentPath + "/" + name;
+            var node = new MemorySnapshotBreakdownTreeNode
+            {
+                Path = path,
+                Name = name,
+                Depth = depth,
+                Allocated = ToLong((ulong)_memorySizeCommitted.GetValue(size)),
+                Resident = residentAvailable ? ToLong((ulong)_memorySizeResident.GetValue(size)) : 0,
+                ResidentAvailable = residentAvailable
+            };
+
+            nodes.Add(node);
+
+            var children = GetChildren(item);
+            if (children.Count == 0)
+                return;
+
+            if (depth >= MemorySnapshotBreakdownTreeLimits.MaxRetainedDepth)
+            {
+                node.ChildrenTruncated = true;
+                return;
+            }
+
+            var retainedChildren = SortItemsForRetention(children)
+                .Take(MemorySnapshotBreakdownTreeLimits.MaxChildrenPerNode)
+                .ToArray();
+            foreach (var child in retainedChildren)
+            {
+                if (nodes.Count >= MemorySnapshotBreakdownTreeLimits.MaxAnalysisNodes)
+                {
+                    node.ChildrenTruncated = true;
+                    break;
+                }
+
+                AddNode(child, path, depth + 1, residentAvailable, nodes);
+                node.RetainedChildrenCount++;
+            }
+
+            if (retainedChildren.Length < children.Count)
+                node.ChildrenTruncated = true;
+        }
+
+        private IEnumerable<object> SortItemsForRetention(IEnumerable<object> items)
+        {
+            return items
+                .OrderByDescending(GetRetentionPriority)
+                .ThenBy(GetItemName, StringComparer.Ordinal);
+        }
+
+        private long GetRetentionPriority(object item)
+        {
+            var size = GetItemSize(item);
+            var committed = ToLong((ulong)_memorySizeCommitted.GetValue(size));
+            var resident = ToLong((ulong)_memorySizeResident.GetValue(size));
+            return Math.Max(committed, resident);
+        }
+
+        private string GetItemName(object item)
+        {
+            var data = GetValue(_treeItemData, item);
+            return _itemDataName.GetValue(data, null) as string ?? "";
+        }
+
+        private object GetItemSize(object item)
+        {
+            var data = GetValue(_treeItemData, item);
+            return _itemDataSize.GetValue(data, null);
+        }
+
+        private List<object> GetChildren(object item)
+        {
+            if (!((bool)GetValue(_treeItemHasChildren, item)))
+                return new List<object>();
+
+            var children = GetValue(_treeItemChildren, item) as IEnumerable;
+            return children == null ? new List<object>() : ToObjectList(children);
+        }
+
+        private static List<object> ToObjectList(IEnumerable items)
+        {
+            var list = new List<object>();
+            foreach (var item in items)
+                list.Add(item);
+            return list;
+        }
+
+        private static Assembly FindMemoryProfilerAssembly()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.GetName().Name == "Unity.MemoryProfiler.Editor")
+                    return assembly;
+            }
+
+            try
+            {
+                return Assembly.Load("Unity.MemoryProfiler.Editor");
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Type GetRequiredType(Assembly assembly, string name)
+        {
+            return assembly.GetType(name, throwOnError: true);
+        }
+
+        private static Type GetRequiredNestedType(Type type, string name)
+        {
+            var nested = type.GetNestedType(name, BindingFlags.Public | BindingFlags.NonPublic);
+            if (nested == null)
+                throw new MissingMemberException(type.FullName, name);
+            return nested;
+        }
+
+        private static ConstructorInfo GetRequiredConstructor(Type type, Type[] parameterTypes)
+        {
+            var constructor = type.GetConstructor(InstanceMembers, null, parameterTypes, null);
+            if (constructor == null)
+                throw new MissingMethodException(type.FullName, ".ctor");
+            return constructor;
+        }
+
+        private static ConstructorInfo GetRequiredConstructor(Type type, int parameterCount)
+        {
+            var constructor = type
+                .GetConstructors(InstanceMembers)
+                .FirstOrDefault(candidate => candidate.GetParameters().Length == parameterCount);
+            if (constructor == null)
+                throw new MissingMethodException(type.FullName, ".ctor");
+            return constructor;
+        }
+
+        private static MethodInfo GetRequiredMethod(Type type, string name, int parameterCount)
+        {
+            var method = type
+                .GetMethods(InstanceMembers | StaticMembers)
+                .FirstOrDefault(candidate => candidate.Name == name && candidate.GetParameters().Length == parameterCount);
+            if (method == null)
+                throw new MissingMethodException(type.FullName, name);
+            return method;
+        }
+
+        private static PropertyInfo GetRequiredProperty(Type type, string name)
+        {
+            var property = type.GetProperty(name, InstanceMembers);
+            if (property == null)
+                throw new MissingMemberException(type.FullName, name);
+            return property;
+        }
+
+        private static FieldInfo GetRequiredField(Type type, string name)
+        {
+            var field = type.GetField(name, InstanceMembers);
+            if (field == null)
+                throw new MissingFieldException(type.FullName, name);
+            return field;
+        }
+
+        private static MemberInfo GetRequiredFieldOrProperty(Type type, string name)
+        {
+            var field = type.GetField(name, InstanceMembers);
+            if (field != null)
+                return field;
+
+            var property = type.GetProperty(name, InstanceMembers);
+            if (property != null)
+                return property;
+
+            throw new MissingMemberException(type.FullName, name);
+        }
+
+        private static object GetValue(MemberInfo member, object target)
+        {
+            var field = member as FieldInfo;
+            if (field != null)
+                return field.GetValue(target);
+
+            return ((PropertyInfo)member).GetValue(target, null);
+        }
+
+        private static long ToLong(ulong value)
+        {
+            return value > long.MaxValue ? long.MaxValue : (long)value;
+        }
+    }
+}
+#endif

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AllTrackedMemoryReflection.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AllTrackedMemoryReflection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50ce037a61553418cbc6c47939198339
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemoryProfilerReflection.cs
@@ -204,6 +204,11 @@ namespace UniCli.Server.Editor.Handlers
             var categories = ExtractCategories(snapshot);
             var nativeData = ExtractNativeData(snapshot);
             var managedData = ExtractManagedData(snapshot);
+            ExtractBreakdownTree(
+                snapshot,
+                categories.Any(category => category.residentAvailable),
+                out var breakdownTree,
+                out var breakdownTreeUnavailableReason);
 
             return new SnapshotAnalysis
             {
@@ -215,6 +220,8 @@ namespace UniCli.Server.Editor.Handlers
                 NativeTypeStats = nativeData.TypeStats,
                 ManagedTypeStats = managedData.TypeStats,
                 TopNativeObjects = nativeData.TopObjects,
+                BreakdownTree = breakdownTree,
+                BreakdownTreeUnavailableReason = breakdownTreeUnavailableReason,
                 NativeObjectCount = nativeData.NativeObjectCount,
                 TotalNativeSize = nativeData.TotalNativeSize,
                 ManagedObjectCount = managedData.ManagedObjectCount,
@@ -261,6 +268,29 @@ namespace UniCli.Server.Editor.Handlers
             }
 
             return categories.ToArray();
+        }
+
+        private static void ExtractBreakdownTree(
+            object snapshot,
+            bool residentAvailable,
+            out MemorySnapshotBreakdownTreeNode[] breakdownTree,
+            out string unavailableReason)
+        {
+            breakdownTree = null;
+            unavailableReason = "";
+
+            if (!AllTrackedMemoryReflection.TryGet(out var reflection, out unavailableReason))
+                return;
+
+            try
+            {
+                breakdownTree = reflection.BuildBreakdownTree(snapshot, residentAvailable);
+            }
+            catch (Exception ex)
+            {
+                breakdownTree = null;
+                unavailableReason = ex.InnerException?.Message ?? ex.Message;
+            }
         }
 
         private NativeExtractionResult ExtractNativeData(object snapshot)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/MemorySnapshotAllOfMemoryHandler.cs
@@ -19,6 +19,7 @@ namespace UniCli.Server.Editor.Handlers
         protected override ValueTask<MemorySnapshotAllOfMemoryResponse> ExecuteAsync(MemorySnapshotAllOfMemoryRequest request, CancellationToken cancellationToken)
         {
             var scope = MemorySnapshotAllOfMemoryScopeParser.Parse(request.scope);
+            var memoryMetric = MemorySnapshotMemoryMetricParser.Parse(request.memoryMetric);
             if (scope == MemorySnapshotAllOfMemoryScope.Managed && !string.IsNullOrEmpty(request.nameFilter))
             {
                 throw new CommandFailedException(
@@ -34,6 +35,7 @@ namespace UniCli.Server.Editor.Handlers
             var includeNativeObjects = (request.includeNativeObjects || !string.IsNullOrEmpty(request.nameFilter)) &&
                 scope != MemorySnapshotAllOfMemoryScope.Managed;
             var includeDiff = request.includeDiff && (!string.IsNullOrEmpty(request.baseSnapshot) || !string.IsNullOrEmpty(request.basePath));
+            var includeBreakdownTree = request.includeBreakdownTree || !string.IsNullOrEmpty(request.pathFilter);
 
             var analysis = GetAnalysisByReferenceOrDefault(
                 request.snapshot,
@@ -60,15 +62,40 @@ namespace UniCli.Server.Editor.Handlers
                     limit = limit,
                     typeFilter = request.typeFilter ?? "",
                     nameFilter = request.nameFilter ?? "",
+                    pathFilter = request.pathFilter ?? "",
+                    pathDepth = request.pathDepth <= 0 ? MemorySnapshotBreakdownTreeLimits.DefaultPathDepth : request.pathDepth,
+                    memoryMetric = MemorySnapshotMemoryMetricParser.Name(memoryMetric),
                     minSize = minSize,
                     minSizeDelta = minSizeDelta,
                     includeCategories = request.includeCategories,
                     includeNativeTypes = includeNativeTypes,
                     includeManagedTypes = includeManagedTypes,
                     includeNativeObjects = includeNativeObjects,
+                    includeBreakdownTree = includeBreakdownTree,
                     includeDiff = includeDiff
                 }
             };
+
+            if (includeBreakdownTree)
+            {
+                var breakdownTree = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                    analysis,
+                    request.pathFilter,
+                    request.pathDepth,
+                    memoryMetric,
+                    minSize,
+                    MemorySnapshotBreakdownTreeLimits.MaxResponseNodes);
+
+                response.filters.pathDepth = breakdownTree.EffectivePathDepth;
+                response.filters.memoryMetric = MemorySnapshotMemoryMetricParser.Name(breakdownTree.EffectiveMemoryMetric);
+                response.breakdownTree = new MemorySnapshotAllOfMemoryBreakdownTreeSection
+                {
+                    included = breakdownTree.Included,
+                    unavailableReason = breakdownTree.UnavailableReason ?? "",
+                    nodes = breakdownTree.Nodes ?? Array.Empty<MemorySnapshotBreakdownTreeNodeInfo>(),
+                    truncated = breakdownTree.Truncated
+                };
+            }
 
             if (includeNativeTypes)
                 response.nativeTypes = ToTypeSection(analysis, MemorySnapshotScope.Native, request.typeFilter, limit, minSize);
@@ -187,12 +214,16 @@ namespace UniCli.Server.Editor.Handlers
         public int limit = 20;
         public string typeFilter;
         public string nameFilter;
+        public string pathFilter;
+        public int pathDepth;
+        public string memoryMetric;
         public long minSize;
         public long minSizeDelta;
         public bool includeCategories = true;
         public bool includeNativeTypes = true;
         public bool includeManagedTypes = true;
         public bool includeNativeObjects;
+        public bool includeBreakdownTree;
         public bool includeDiff = true;
     }
 
@@ -211,6 +242,7 @@ namespace UniCli.Server.Editor.Handlers
         public MemorySnapshotAllOfMemoryTypeSection nativeTypes;
         public MemorySnapshotAllOfMemoryTypeSection managedTypes;
         public MemorySnapshotAllOfMemoryObjectSection nativeObjects;
+        public MemorySnapshotAllOfMemoryBreakdownTreeSection breakdownTree;
         public MemorySnapshotAllOfMemoryDiffSection diff;
         public MemorySnapshotAllOfMemoryFilterInfo filters;
     }
@@ -222,12 +254,16 @@ namespace UniCli.Server.Editor.Handlers
         public int limit;
         public string typeFilter;
         public string nameFilter;
+        public string pathFilter;
+        public int pathDepth;
+        public string memoryMetric;
         public long minSize;
         public long minSizeDelta;
         public bool includeCategories;
         public bool includeNativeTypes;
         public bool includeManagedTypes;
         public bool includeNativeObjects;
+        public bool includeBreakdownTree;
         public bool includeDiff;
     }
 
@@ -248,6 +284,15 @@ namespace UniCli.Server.Editor.Handlers
     {
         public bool included;
         public MemorySnapshotNativeObjectInfo[] objects;
+        public bool truncated;
+    }
+
+    [Serializable]
+    public class MemorySnapshotAllOfMemoryBreakdownTreeSection
+    {
+        public bool included;
+        public string unavailableReason;
+        public MemorySnapshotBreakdownTreeNodeInfo[] nodes;
         public bool truncated;
     }
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/SnapshotAnalysis.cs
@@ -21,6 +21,8 @@ namespace UniCli.Server.Editor.Handlers
         public MemorySnapshotNativeTypeStat[] NativeTypeStats;
         public MemorySnapshotNativeTypeStat[] ManagedTypeStats;
         public RetainedNativeObjectInfo[] TopNativeObjects;
+        public MemorySnapshotBreakdownTreeNode[] BreakdownTree;
+        public string BreakdownTreeUnavailableReason;
         public long NativeObjectCount;
         public long TotalNativeSize;
         public long ManagedObjectCount;
@@ -45,6 +47,18 @@ namespace UniCli.Server.Editor.Handlers
                 instanceId = InstanceId
             };
         }
+    }
+
+    internal sealed class MemorySnapshotBreakdownTreeNode
+    {
+        public string Path;
+        public string Name;
+        public int Depth;
+        public long Allocated;
+        public long Resident;
+        public bool ResidentAvailable;
+        public int RetainedChildrenCount;
+        public bool ChildrenTruncated;
     }
 
     internal sealed class NativeObjectRetainer
@@ -362,6 +376,81 @@ namespace UniCli.Server.Editor.Handlers
             };
         }
 
+        public static MemorySnapshotBreakdownTreeResult GetBreakdownTree(
+            SnapshotAnalysis analysis,
+            string pathFilter,
+            int pathDepth,
+            MemorySnapshotMemoryMetric memoryMetric,
+            long minSize,
+            int responseLimit)
+        {
+            var source = analysis.BreakdownTree;
+            var hasResident = source != null && source.Any(node => node.ResidentAvailable);
+            var effectiveMetric = memoryMetric == MemorySnapshotMemoryMetric.Resident && !hasResident
+                ? MemorySnapshotMemoryMetric.Allocated
+                : memoryMetric;
+
+            if (source == null)
+            {
+                return new MemorySnapshotBreakdownTreeResult
+                {
+                    Included = false,
+                    UnavailableReason = string.IsNullOrEmpty(analysis.BreakdownTreeUnavailableReason)
+                        ? "All Of Memory breakdown tree is unavailable."
+                        : analysis.BreakdownTreeUnavailableReason,
+                    Nodes = Array.Empty<MemorySnapshotBreakdownTreeNodeInfo>(),
+                    EffectivePathDepth = ClampBreakdownPathDepth(pathDepth, 0),
+                    EffectiveMemoryMetric = effectiveMetric
+                };
+            }
+
+            var clampedMinSize = Math.Max(0, minSize);
+            var pathSegments = SplitPath(pathFilter);
+            var pathLookup = BuildPathLookup(source);
+            var match = pathSegments.Length > 0 ? FindPathMatch(source, pathSegments) : null;
+            var maxRelativeDepth = GetMaxRelativeDepth(source, match, pathSegments.Length > 0);
+            var effectivePathDepth = ClampBreakdownPathDepth(pathDepth, maxRelativeDepth);
+
+            if (pathSegments.Length > 0 && match == null)
+            {
+                return new MemorySnapshotBreakdownTreeResult
+                {
+                    Included = true,
+                    Nodes = Array.Empty<MemorySnapshotBreakdownTreeNodeInfo>(),
+                    EffectivePathDepth = effectivePathDepth,
+                    EffectiveMemoryMetric = effectiveMetric
+                };
+            }
+
+            var includePaths = BuildBreakdownIncludeSet(
+                source,
+                pathLookup,
+                match,
+                pathSegments.Length > 0,
+                effectivePathDepth,
+                effectiveMetric,
+                clampedMinSize);
+            var filtered = source
+                .Where(node => includePaths.Contains(node.Path))
+                .ToArray();
+            var ordered = SortBreakdownPreOrder(filtered, effectiveMetric);
+            var clampedLimit = MemorySnapshotBreakdownTreeLimits.ClampResponseLimit(responseLimit);
+            var limited = ordered.Take(clampedLimit).ToArray();
+            var limitedPathSet = new HashSet<string>(limited.Select(node => node.Path), StringComparer.OrdinalIgnoreCase);
+            var returnedChildrenCounts = CountReturnedChildren(limited);
+
+            return new MemorySnapshotBreakdownTreeResult
+            {
+                Included = true,
+                Nodes = limited
+                    .Select(node => ToBreakdownTreeInfo(node, limitedPathSet, returnedChildrenCounts))
+                    .ToArray(),
+                Truncated = ordered.Length > clampedLimit || limited.Any(node => HasHiddenChildren(node, limitedPathSet)),
+                EffectivePathDepth = effectivePathDepth,
+                EffectiveMemoryMetric = effectiveMetric
+            };
+        }
+
         public static MemorySnapshotNativeTypeStat[] GetTypeStats(SnapshotAnalysis analysis, MemorySnapshotScope scope)
         {
             return scope == MemorySnapshotScope.Managed
@@ -377,6 +466,272 @@ namespace UniCli.Server.Editor.Handlers
         public static long GetTotalSize(SnapshotAnalysis analysis, MemorySnapshotScope scope)
         {
             return scope == MemorySnapshotScope.Managed ? analysis.TotalManagedObjectSize : analysis.TotalNativeSize;
+        }
+
+        private static HashSet<string> BuildBreakdownIncludeSet(
+            MemorySnapshotBreakdownTreeNode[] source,
+            Dictionary<string, MemorySnapshotBreakdownTreeNode> pathLookup,
+            MemorySnapshotBreakdownTreeNode match,
+            bool hasPathFilter,
+            int effectivePathDepth,
+            MemorySnapshotMemoryMetric metric,
+            long minSize)
+        {
+            var includePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var node in source)
+            {
+                if (!IsWithinBreakdownDepth(node, match, hasPathFilter, effectivePathDepth))
+                    continue;
+
+                var isContextNode = hasPathFilter && IsAncestorOrSelf(node.Path, match.Path);
+                if (!isContextNode && MetricValue(node, metric) < minSize)
+                    continue;
+
+                AddNodeAndAncestors(includePaths, pathLookup, node.Path);
+            }
+
+            return includePaths;
+        }
+
+        private static bool IsWithinBreakdownDepth(
+            MemorySnapshotBreakdownTreeNode node,
+            MemorySnapshotBreakdownTreeNode match,
+            bool hasPathFilter,
+            int effectivePathDepth)
+        {
+            if (!hasPathFilter)
+                return node.Depth <= effectivePathDepth;
+
+            if (IsAncestorOrSelf(node.Path, match.Path))
+                return true;
+
+            return IsAncestorOrSelf(match.Path, node.Path) &&
+                node.Depth - match.Depth <= effectivePathDepth;
+        }
+
+        private static MemorySnapshotBreakdownTreeNode[] SortBreakdownPreOrder(
+            MemorySnapshotBreakdownTreeNode[] nodes,
+            MemorySnapshotMemoryMetric metric)
+        {
+            var nodePaths = new HashSet<string>(nodes.Select(node => node.Path), StringComparer.OrdinalIgnoreCase);
+            var roots = new List<MemorySnapshotBreakdownTreeNode>();
+            var childrenByParent = new Dictionary<string, List<MemorySnapshotBreakdownTreeNode>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var node in nodes)
+            {
+                var parentPath = GetParentPath(node.Path);
+                if (parentPath.Length == 0 || !nodePaths.Contains(parentPath))
+                {
+                    roots.Add(node);
+                    continue;
+                }
+
+                if (!childrenByParent.TryGetValue(parentPath, out var children))
+                {
+                    children = new List<MemorySnapshotBreakdownTreeNode>();
+                    childrenByParent[parentPath] = children;
+                }
+
+                children.Add(node);
+            }
+
+            var result = new List<MemorySnapshotBreakdownTreeNode>(nodes.Length);
+            AddSortedBreakdownNodes(roots, childrenByParent, metric, result);
+            return result.ToArray();
+        }
+
+        private static void AddSortedBreakdownNodes(
+            List<MemorySnapshotBreakdownTreeNode> nodes,
+            Dictionary<string, List<MemorySnapshotBreakdownTreeNode>> childrenByParent,
+            MemorySnapshotMemoryMetric metric,
+            List<MemorySnapshotBreakdownTreeNode> result)
+        {
+            foreach (var node in SortBreakdownSiblings(nodes, metric))
+            {
+                result.Add(node);
+                if (childrenByParent.TryGetValue(node.Path, out var children))
+                    AddSortedBreakdownNodes(children, childrenByParent, metric, result);
+            }
+        }
+
+        private static IEnumerable<MemorySnapshotBreakdownTreeNode> SortBreakdownSiblings(
+            IEnumerable<MemorySnapshotBreakdownTreeNode> nodes,
+            MemorySnapshotMemoryMetric metric)
+        {
+            return nodes
+                .OrderByDescending(node => MetricValue(node, metric))
+                .ThenBy(node => node.Name, StringComparer.Ordinal)
+                .ThenBy(node => node.Path, StringComparer.Ordinal);
+        }
+
+        private static MemorySnapshotBreakdownTreeNodeInfo ToBreakdownTreeInfo(
+            MemorySnapshotBreakdownTreeNode node,
+            HashSet<string> returnedPathSet,
+            Dictionary<string, int> returnedChildrenCounts)
+        {
+            returnedChildrenCounts.TryGetValue(node.Path, out var childrenCount);
+            return new MemorySnapshotBreakdownTreeNodeInfo
+            {
+                path = node.Path,
+                name = node.Name,
+                depth = node.Depth,
+                allocated = node.Allocated,
+                resident = node.Resident,
+                residentAvailable = node.ResidentAvailable,
+                childrenCount = childrenCount,
+                childrenTruncated = HasHiddenChildren(node, returnedPathSet)
+            };
+        }
+
+        private static bool HasHiddenChildren(
+            MemorySnapshotBreakdownTreeNode node,
+            HashSet<string> returnedPathSet)
+        {
+            var returnedChildrenCount = 0;
+            foreach (var path in returnedPathSet)
+            {
+                if (IsDirectChildPath(node.Path, path))
+                    returnedChildrenCount++;
+            }
+
+            return node.ChildrenTruncated || node.RetainedChildrenCount > returnedChildrenCount;
+        }
+
+        private static Dictionary<string, int> CountReturnedChildren(MemorySnapshotBreakdownTreeNode[] nodes)
+        {
+            var returnedPathSet = new HashSet<string>(nodes.Select(node => node.Path), StringComparer.OrdinalIgnoreCase);
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var node in nodes)
+            {
+                var parentPath = GetParentPath(node.Path);
+                if (parentPath.Length == 0 || !returnedPathSet.Contains(parentPath))
+                    continue;
+
+                counts.TryGetValue(parentPath, out var count);
+                counts[parentPath] = count + 1;
+            }
+
+            return counts;
+        }
+
+        private static int GetMaxRelativeDepth(
+            MemorySnapshotBreakdownTreeNode[] source,
+            MemorySnapshotBreakdownTreeNode match,
+            bool hasPathFilter)
+        {
+            if (source.Length == 0)
+                return 0;
+
+            if (!hasPathFilter)
+                return source.Max(node => node.Depth);
+
+            if (match == null)
+                return source.Max(node => node.Depth);
+
+            return source
+                .Where(node => IsAncestorOrSelf(match.Path, node.Path))
+                .Select(node => node.Depth - match.Depth)
+                .DefaultIfEmpty(0)
+                .Max();
+        }
+
+        private static int ClampBreakdownPathDepth(int pathDepth, int maxDepth)
+        {
+            var requested = pathDepth <= 0 ? MemorySnapshotBreakdownTreeLimits.DefaultPathDepth : pathDepth;
+            return Math.Max(0, Math.Min(requested, Math.Max(0, maxDepth)));
+        }
+
+        private static MemorySnapshotBreakdownTreeNode FindPathMatch(
+            MemorySnapshotBreakdownTreeNode[] nodes,
+            string[] pathSegments)
+        {
+            return nodes.FirstOrDefault(node => MatchesPathSegments(node.Path, pathSegments));
+        }
+
+        private static bool MatchesPathSegments(string path, string[] pathSegments)
+        {
+            var nodeSegments = SplitPath(path);
+            if (nodeSegments.Length != pathSegments.Length)
+                return false;
+
+            for (var i = 0; i < nodeSegments.Length; i++)
+            {
+                if (!string.Equals(nodeSegments[i], pathSegments[i], StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static string[] SplitPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return Array.Empty<string>();
+
+            return path
+                .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(segment => segment.Trim())
+                .Where(segment => segment.Length > 0)
+                .ToArray();
+        }
+
+        private static Dictionary<string, MemorySnapshotBreakdownTreeNode> BuildPathLookup(
+            MemorySnapshotBreakdownTreeNode[] nodes)
+        {
+            var lookup = new Dictionary<string, MemorySnapshotBreakdownTreeNode>(StringComparer.OrdinalIgnoreCase);
+            foreach (var node in nodes)
+            {
+                if (!lookup.ContainsKey(node.Path))
+                    lookup.Add(node.Path, node);
+            }
+
+            return lookup;
+        }
+
+        private static void AddNodeAndAncestors(
+            HashSet<string> includePaths,
+            Dictionary<string, MemorySnapshotBreakdownTreeNode> pathLookup,
+            string path)
+        {
+            while (!string.IsNullOrEmpty(path))
+            {
+                if (!pathLookup.ContainsKey(path))
+                    break;
+
+                includePaths.Add(path);
+                path = GetParentPath(path);
+            }
+        }
+
+        private static string GetParentPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return "";
+
+            var index = path.LastIndexOf('/');
+            return index <= 0 ? "" : path.Substring(0, index);
+        }
+
+        private static bool IsAncestorOrSelf(string ancestorPath, string path)
+        {
+            if (string.Equals(ancestorPath, path, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return path.StartsWith(ancestorPath + "/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsDirectChildPath(string parentPath, string path)
+        {
+            if (!IsAncestorOrSelf(parentPath, path) || string.Equals(parentPath, path, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return string.Equals(GetParentPath(path), parentPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static long MetricValue(MemorySnapshotBreakdownTreeNode node, MemorySnapshotMemoryMetric metric)
+        {
+            return metric == MemorySnapshotMemoryMetric.Resident ? node.Resident : node.Allocated;
         }
 
         private static bool Matches(string value, string filter)
@@ -439,6 +794,24 @@ namespace UniCli.Server.Editor.Handlers
         }
     }
 
+    internal static class MemorySnapshotBreakdownTreeLimits
+    {
+        public const int DefaultPathDepth = 2;
+        public const int MaxRetainedDepth = 4;
+        public const int MaxAnalysisNodes = 5000;
+        public const int MaxChildrenPerNode = 50;
+        public const int MaxResponseNodes = 500;
+
+        public static int ClampResponseLimit(int limit)
+        {
+            if (limit <= 0)
+                return MaxResponseNodes;
+            if (limit > MaxResponseNodes)
+                return MaxResponseNodes;
+            return limit;
+        }
+    }
+
     internal enum MemorySnapshotScope
     {
         Native,
@@ -464,6 +837,43 @@ namespace UniCli.Server.Editor.Handlers
         }
     }
 
+    internal enum MemorySnapshotMemoryMetric
+    {
+        Allocated,
+        Resident,
+        Both
+    }
+
+    internal static class MemorySnapshotMemoryMetricParser
+    {
+        public static MemorySnapshotMemoryMetric Parse(string metric)
+        {
+            if (string.IsNullOrEmpty(metric) ||
+                string.Equals(metric, "allocated", StringComparison.OrdinalIgnoreCase))
+            {
+                return MemorySnapshotMemoryMetric.Allocated;
+            }
+
+            if (string.Equals(metric, "resident", StringComparison.OrdinalIgnoreCase))
+                return MemorySnapshotMemoryMetric.Resident;
+
+            if (string.Equals(metric, "both", StringComparison.OrdinalIgnoreCase))
+                return MemorySnapshotMemoryMetric.Both;
+
+            throw new CommandFailedException(
+                "Unknown memory metric: " + metric + ". Valid values are: allocated, resident, both.",
+                null);
+        }
+
+        public static string Name(MemorySnapshotMemoryMetric metric)
+        {
+            if (metric == MemorySnapshotMemoryMetric.Resident)
+                return "resident";
+
+            return metric == MemorySnapshotMemoryMetric.Both ? "both" : "allocated";
+        }
+    }
+
     internal sealed class MemorySnapshotTypeStatResult
     {
         public MemorySnapshotNativeTypeStat[] Types;
@@ -476,6 +886,16 @@ namespace UniCli.Server.Editor.Handlers
         public MemorySnapshotNativeTypeDiffInfo[] Types;
         public long OthersCount;
         public long OthersSize;
+    }
+
+    internal sealed class MemorySnapshotBreakdownTreeResult
+    {
+        public bool Included;
+        public string UnavailableReason;
+        public MemorySnapshotBreakdownTreeNodeInfo[] Nodes;
+        public bool Truncated;
+        public int EffectivePathDepth;
+        public MemorySnapshotMemoryMetric EffectiveMemoryMetric;
     }
 
     [Serializable]
@@ -503,6 +923,19 @@ namespace UniCli.Server.Editor.Handlers
         public long committed;
         public long resident;
         public bool residentAvailable;
+    }
+
+    [Serializable]
+    public sealed class MemorySnapshotBreakdownTreeNodeInfo
+    {
+        public string path;
+        public string name;
+        public int depth;
+        public long allocated;
+        public long resident;
+        public bool residentAvailable;
+        public int childrenCount;
+        public bool childrenTruncated;
     }
 
     [Serializable]

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/Tests/MemorySnapshotAnalysisQueriesTests.cs
@@ -172,6 +172,160 @@ namespace UniCli.Server.Editor.MemorySnapshot.Tests
         }
 
         [Test]
+        public void Unit_GetBreakdownTree_PathFilterRootExact_IncludesAncestorsAndDescendants()
+        {
+            var analysis = BreakdownAnalysis(
+                BreakdownNode("Native", allocated: 100, resident: 90),
+                BreakdownNode("Native/Unity Subsystems", allocated: 70, resident: 65),
+                BreakdownNode("Native/Unity Subsystems/Textures", allocated: 40, resident: 35),
+                BreakdownNode("Native/Native Objects", allocated: 30, resident: 25),
+                BreakdownNode("Managed", allocated: 50, resident: 45));
+
+            var result = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "native/unity subsystems",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+
+            CollectionAssert.AreEqual(new[]
+            {
+                "Native",
+                "Native/Unity Subsystems",
+                "Native/Unity Subsystems/Textures"
+            }, result.Nodes.Select(node => node.path).ToArray());
+            Assert.AreEqual(1, result.Nodes[0].childrenCount);
+            Assert.AreEqual(1, result.Nodes[1].childrenCount);
+        }
+
+        [Test]
+        public void Unit_GetBreakdownTree_PathFilterNonRootSegment_ReturnsEmptySection()
+        {
+            var analysis = BreakdownAnalysis(
+                BreakdownNode("Native", allocated: 100, resident: 90),
+                BreakdownNode("Native/Unity Subsystems", allocated: 70, resident: 65));
+
+            var result = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "Unity Subsystems",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+
+            Assert.IsTrue(result.Included);
+            Assert.AreEqual(0, result.Nodes.Length);
+        }
+
+        [Test]
+        public void Unit_GetBreakdownTree_PathDepth_DefaultRelativeAndClamp_AppliesToRequestedRoot()
+        {
+            var analysis = BreakdownAnalysis(
+                BreakdownNode("Native", allocated: 100, resident: 90),
+                BreakdownNode("Native/Native Objects", allocated: 40, resident: 30),
+                BreakdownNode("Native/Unity Subsystems", allocated: 70, resident: 65),
+                BreakdownNode("Native/Unity Subsystems/Textures", allocated: 40, resident: 35),
+                BreakdownNode("Native/Unity Subsystems/Textures/Texture2D", allocated: 30, resident: 20));
+
+            var defaultDepth = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "",
+                pathDepth: 0,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+            var pathRelative = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "Native/Unity Subsystems",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+            var clamped = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "",
+                pathDepth: 99,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+
+            Assert.AreEqual(2, defaultDepth.EffectivePathDepth);
+            CollectionAssert.DoesNotContain(defaultDepth.Nodes.Select(node => node.path).ToArray(), "Native/Unity Subsystems/Textures/Texture2D");
+            Assert.AreEqual(1, pathRelative.EffectivePathDepth);
+            CollectionAssert.AreEqual(new[]
+            {
+                "Native",
+                "Native/Unity Subsystems",
+                "Native/Unity Subsystems/Textures"
+            }, pathRelative.Nodes.Select(node => node.path).ToArray());
+            Assert.AreEqual(3, clamped.EffectivePathDepth);
+        }
+
+        [Test]
+        public void Unit_GetBreakdownTree_MemoryMetricResident_FiltersAndFallsBackWhenUnavailable()
+        {
+            var analysis = BreakdownAnalysis(
+                BreakdownNode("Native", allocated: 100, resident: 100),
+                BreakdownNode("Native/AllocatedLarge", allocated: 80, resident: 1),
+                BreakdownNode("Native/ResidentLarge", allocated: 10, resident: 70));
+
+            var resident = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "Native",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Resident,
+                minSize: 50,
+                responseLimit: 500);
+            var unavailable = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                BreakdownAnalysis(
+                    BreakdownNode("Native", allocated: 100, resident: 0, residentAvailable: false),
+                    BreakdownNode("Native/AllocatedLarge", allocated: 80, resident: 0, residentAvailable: false),
+                    BreakdownNode("Native/ResidentLarge", allocated: 10, resident: 0, residentAvailable: false)),
+                pathFilter: "Native",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Resident,
+                minSize: 50,
+                responseLimit: 500);
+
+            CollectionAssert.AreEqual(new[] { "Native", "Native/ResidentLarge" }, resident.Nodes.Select(node => node.path).ToArray());
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Resident, resident.EffectiveMemoryMetric);
+            CollectionAssert.AreEqual(new[] { "Native", "Native/AllocatedLarge" }, unavailable.Nodes.Select(node => node.path).ToArray());
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Allocated, unavailable.EffectiveMemoryMetric);
+        }
+
+        [Test]
+        public void Unit_GetBreakdownTree_ResponseLimitAndDepth_MarkReturnedChildrenTruncated()
+        {
+            var analysis = BreakdownAnalysis(
+                BreakdownNode("Native", allocated: 100, resident: 90),
+                BreakdownNode("Native/A", allocated: 60, resident: 50),
+                BreakdownNode("Native/A/Deep", allocated: 30, resident: 20),
+                BreakdownNode("Native/B", allocated: 50, resident: 40));
+
+            var depthLimited = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "Native",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 500);
+            var responseLimited = MemorySnapshotAnalysisQueries.GetBreakdownTree(
+                analysis,
+                pathFilter: "Native",
+                pathDepth: 1,
+                memoryMetric: MemorySnapshotMemoryMetric.Allocated,
+                minSize: 0,
+                responseLimit: 2);
+
+            Assert.AreEqual(0, depthLimited.Nodes[1].childrenCount);
+            Assert.IsTrue(depthLimited.Nodes[1].childrenTruncated);
+            Assert.IsTrue(responseLimited.Truncated);
+            Assert.AreEqual(1, responseLimited.Nodes[0].childrenCount);
+            Assert.IsTrue(responseLimited.Nodes[0].childrenTruncated);
+        }
+
+        [Test]
         public void Unit_ResolveDefaultSnapshot_SelectsLatestAndSecondLatestByMtime()
         {
             var directory = Path.Combine(Path.GetTempPath(), "unicli-memorysnapshot-" + Guid.NewGuid().ToString("N"));
@@ -297,6 +451,7 @@ namespace UniCli.Server.Editor.MemorySnapshot.Tests
             Assert.IsTrue(request.includeNativeTypes);
             Assert.IsTrue(request.includeManagedTypes);
             Assert.IsFalse(request.includeNativeObjects);
+            Assert.IsFalse(request.includeBreakdownTree);
             Assert.IsTrue(request.includeDiff);
         }
 
@@ -310,6 +465,16 @@ namespace UniCli.Server.Editor.MemorySnapshot.Tests
             Assert.Throws<CommandFailedException>(() => MemorySnapshotAllOfMemoryScopeParser.Parse("objects"));
         }
 
+        [Test]
+        public void Unit_MemoryMetricParser_VariousInputs_ReturnsExpected()
+        {
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Allocated, MemorySnapshotMemoryMetricParser.Parse(""));
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Allocated, MemorySnapshotMemoryMetricParser.Parse("allocated"));
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Resident, MemorySnapshotMemoryMetricParser.Parse("resident"));
+            Assert.AreEqual(MemorySnapshotMemoryMetric.Both, MemorySnapshotMemoryMetricParser.Parse("both"));
+            Assert.Throws<CommandFailedException>(() => MemorySnapshotMemoryMetricParser.Parse("committed"));
+        }
+
         private static SnapshotAnalysis Analysis(params MemorySnapshotNativeTypeStat[] typeStats)
         {
             return new SnapshotAnalysis
@@ -318,6 +483,49 @@ namespace UniCli.Server.Editor.MemorySnapshot.Tests
                 ManagedTypeStats = new MemorySnapshotNativeTypeStat[0],
                 TopNativeObjects = new RetainedNativeObjectInfo[0]
             };
+        }
+
+        private static SnapshotAnalysis BreakdownAnalysis(params MemorySnapshotBreakdownTreeNode[] breakdownTree)
+        {
+            foreach (var node in breakdownTree)
+            {
+                node.RetainedChildrenCount = breakdownTree.Count(candidate => IsDirectChild(node.Path, candidate.Path));
+            }
+
+            return new SnapshotAnalysis
+            {
+                BreakdownTree = breakdownTree,
+                Categories = new MemorySnapshotCategoryInfo[0],
+                NativeTypeStats = new MemorySnapshotNativeTypeStat[0],
+                ManagedTypeStats = new MemorySnapshotNativeTypeStat[0],
+                TopNativeObjects = new RetainedNativeObjectInfo[0]
+            };
+        }
+
+        private static MemorySnapshotBreakdownTreeNode BreakdownNode(
+            string path,
+            long allocated,
+            long resident,
+            bool residentAvailable = true)
+        {
+            var nameStart = path.LastIndexOf('/') + 1;
+            return new MemorySnapshotBreakdownTreeNode
+            {
+                Path = path,
+                Name = path.Substring(nameStart),
+                Depth = path.Count(character => character == '/'),
+                Allocated = allocated,
+                Resident = resident,
+                ResidentAvailable = residentAvailable
+            };
+        }
+
+        private static bool IsDirectChild(string parentPath, string path)
+        {
+            if (!path.StartsWith(parentPath + "/", StringComparison.Ordinal))
+                return false;
+
+            return path.IndexOf('/', parentPath.Length + 1) < 0;
         }
 
         private static MemorySnapshotNativeTypeStat TypeStat(string typeName, long count, long totalSize)


### PR DESCRIPTION
## Summary
- Extend `MemorySnapshot.AllOfMemory` with bounded All Of Memory `breakdownTree` output.
- Add `pathFilter`, `pathDepth`, and `memoryMetric` so reports can focus on paths such as `Native/Unity Subsystems` without dumping the full tree.
- Keep the Memory Profiler internal AllTrackedMemory reflection optional so existing MemorySnapshot commands continue to work when that API is unavailable.

## Impact
- Adds `includeBreakdownTree`, `pathFilter`, `pathDepth`, and `memoryMetric` request fields to `MemorySnapshot.AllOfMemory`.
- Adds a flat `breakdownTree` response section with `path`, `allocated`, `resident`, `residentAvailable`, and returned child metadata.
- `pathFilter` only applies to `breakdownTree`; `typeFilter`, `nameFilter`, type sections, and native object sections keep their existing behavior.
- `memoryMetric` only affects `breakdownTree` sorting and `minSize`; allocated-only type/object sections remain unchanged.
- Initial snapshot analysis may do additional AllTrackedMemory work; cache hits reuse the retained analysis.
- Updates README, CLAUDE.md, Claude plugin skill guidance, and local agent skill guidance.

## Test
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/Editor/Handlers/MemorySnapshot/AllTrackedMemoryReflection.cs" --json` → success.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --json` → `81 passed`, `0 failed`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec MemorySnapshot.AllOfMemory '{"path":"/Users/a13946/Repositories/github-work/applibot-romance/romance-client/romance-unity/MemoryCaptures/capture_20260612_122240.snap","pathFilter":"Native/Unity Subsystems","pathDepth":1,"memoryMetric":"both","includeCategories":false,"includeNativeTypes":false,"includeManagedTypes":false,"includeDiff":false}' --json` → success, `breakdownTree.included: true`, `Native/Unity Subsystems` returned with allocated and resident values.
- `git diff --check HEAD` → success.

## Open items
- None.