### PR TITLE
Release v1.4.1

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/Protocol/Result.cs
+++ b/src/UniCli.Client/Protocol/Result.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace UniCli.Protocol

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Protocol/Result.cs
+++ b/src/UniCli.Protocol/Result.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace UniCli.Protocol

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
### Summary

Prepares the `v1.4.1` patch release.

This release includes the `MemorySnapshot.AllOfMemory` breakdown tree / path filter extension merged in #149. It bumps the CLI, Unity package, Claude plugin, and local agent skill metadata versions from `1.4.0` to `1.4.1`.

### Impact

- Updates the CLI package version to `1.4.1`.
- Updates `com.yucchiy.unicli-server` package metadata to `1.4.1`.
- Updates Claude plugin marketplace and skill metadata to `1.4.1`.
- Updates local agent skill metadata to `1.4.1`.
- Includes `MemorySnapshot.AllOfMemory` `breakdownTree`, `pathFilter`, `pathDepth`, and `memoryMetric` support for focused All Of Memory reporting.
- Keeps generated Protocol copies aligned by preserving `#nullable enable` on `Result.cs`, avoiding extra Unity nullable warnings after Protocol sync.

### Tests

- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/package.json" --json` → success.
- `dotnet build src/UniCli.Protocol` → success with existing nullable warnings.
- `dotnet publish src/UniCli.Client -o .build` → success with existing nullable / AOT / linker warnings.
- `.build/unicli --version` → `1.4.1`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 2` existing obsolete warnings.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `81 passed`, `0 failed`.
- `git diff --check` → success.

### Unresolved

- After this PR is merged, create and push the release tag: `git tag v1.4.1 && git push origin v1.4.1`.