### PR TITLE
fix: Truncating stackTrace in EditorLogGetHandler affects original stackTrace

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/EditorLogManager.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/EditorLogManager.cs
@@ -11,6 +11,17 @@ namespace UniCli.Server.Editor
         public string stackTrace;
         public string type;
         public string timestamp;
+
+        public LogEntry Clone()
+        {
+            return new LogEntry
+            {
+                message = message,
+                stackTrace = stackTrace,
+                type = type,
+                timestamp = timestamp
+            };
+        }
     }
 
     [Serializable]
@@ -65,7 +76,13 @@ namespace UniCli.Server.Editor
         {
             lock (_lock)
             {
-                return _logBuffer.ToArray();
+                var logs = new LogEntry[_logBuffer.Count];
+                var i = 0;
+                foreach (var entry in _logBuffer)
+                {
+                    logs[i++] = entry.Clone();
+                }
+                return logs;
             }
         }
 
@@ -95,7 +112,7 @@ namespace UniCli.Server.Editor
                     if (filterBySearch && !entry.message.Contains(searchText, StringComparison.OrdinalIgnoreCase))
                         continue;
 
-                    result.Add(entry);
+                    result.Add(entry.Clone());
                 }
             }
 


### PR DESCRIPTION
https://github.com/yucchiy/UniCli/blob/9ab2a18546a1358c95a1ff8a989ad108c319d5b2/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Console/EditorLogHandler.cs#L27

`EditorLogGetHandler` truncates the original `stackTrace` when `stackTraceLines` is specified, causing subsequent requests to lose stack trace lines. For example, if a user first requests stackTraceLines = 1 and then stackTraceLines = 2, all lines after the first have already been removed and are no longer available. This PR fixes the issue by cloning the original `stackTrace`.