### PR TITLE
feat: add Scene.Screenshot2D / Scene.Screenshot3D commands

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -114,6 +114,15 @@ unicli exec TestRunner.RunEditMode --json
 unicli exec TestRunner.RunPlayMode --json
 ```
 
+**Capture SceneView screenshots (works in Edit Mode, no Play Mode required):**
+
+```bash
+# 2D mode (orthographic, facing the XY plane); lookAt is a GameObject path, offset shifts the capture center
+unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path":"Screenshots/map.png"}' --json
+# 3D mode: orbit the lookAt point by yaw/pitch at the given distance
+unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
+```
+
 **Inspect and modify settings:**
 
 ```bash

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -117,6 +117,15 @@ unicli exec TestRunner.RunEditMode --json
 unicli exec TestRunner.RunPlayMode --json
 ```
 
+**Capture SceneView screenshots (works in Edit Mode, no Play Mode required):**
+
+```bash
+# 2D mode (orthographic, facing the XY plane); lookAt is a GameObject path, offset shifts the capture center
+unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path":"Screenshots/map.png"}' --json
+# 3D mode: orbit the lookAt point by yaw/pitch at the given distance
+unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
+```
+
 **Inspect and modify settings:**
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.SetActive '{"name":"Sam
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Save '{"all":true}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Close '{"name":"Additive"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.New '{"empty":true,"additive":true}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path":"Screenshots/map.png"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
 
 # PackageManager operations
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec PackageManager.GetInfo '{"name":"com.unity.test-framework"}' --json

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ unicli exec GameObject.AddComponent --path "Enemy" --typeName BoxCollider
 unicli exec Scene.Open --path "Assets/Scenes/Level1.unity"
 unicli exec Scene.Save --all
 
+# SceneView screenshots (lookAt: GameObject path; offset: added to the lookAt position)
+unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path":"Screenshots/map.png"}'
+unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}'
+
 # Pre-flight before commands that can trigger scene-save dialogs (text output is compact)
 unicli exec Editor.Status
 # Save only when the dirty scenes are your own intended persistent changes.
@@ -534,6 +538,8 @@ The following commands are built in. Run `unicli commands` to see this list from
 | `Scene.Close` | Close a loaded scene |
 | `Scene.Save` | Save a scene or all open scenes |
 | `Scene.New` | Create a new scene |
+| `Scene.Screenshot2D` | Capture a SceneView screenshot in 2D mode (orthographic) as PNG |
+| `Scene.Screenshot3D` | Capture a SceneView screenshot in 3D mode (orbit by yaw/pitch/distance) as PNG |
 
 ### Asset
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot2DHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot2DHandler.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("Scene")]
+    public sealed class SceneScreenshot2DHandler : CommandHandler<SceneScreenshot2DRequest, SceneScreenshotResponse>
+    {
+        public override string CommandName => "Scene.Screenshot2D";
+        public override string Description => "Capture a screenshot of the SceneView in 2D mode (orthographic, facing the XY plane) and save as PNG";
+
+        protected override bool TryWriteFormatted(SceneScreenshotResponse response, bool success, IFormatWriter writer)
+            => SceneViewScreenshotUtility.TryWriteResult(response, success, writer);
+
+        protected override ValueTask<SceneScreenshotResponse> ExecuteAsync(SceneScreenshot2DRequest request, CancellationToken cancellationToken)
+        {
+            var sceneView = SceneViewScreenshotUtility.GetOrCreateSceneView();
+            var options = new SceneViewScreenshotUtility.CaptureOptions
+            {
+                orthographic = true,
+                pivot = SceneViewScreenshotUtility.ResolvePivot(sceneView, request.lookAt, request.offset, allowTwoComponentOffset: true),
+                rotation = Quaternion.identity,
+                size = request.size > 0f ? request.size : sceneView.size,
+                width = request.width,
+                height = request.height
+            };
+
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Screenshots", $"sceneview2d_{DateTime.Now:yyyyMMdd_HHmmss}.png")
+                : request.path;
+            path = ResolvePath(path);
+
+            Texture2D texture = null;
+            try
+            {
+                texture = SceneViewScreenshotUtility.Capture(sceneView, options);
+                return new ValueTask<SceneScreenshotResponse>(SceneViewScreenshotUtility.SavePng(texture, path));
+            }
+            finally
+            {
+                if (texture != null)
+                    UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+    }
+
+    [Serializable]
+    public class SceneScreenshot2DRequest
+    {
+        public string path;
+        public string lookAt;
+        public float[] offset;
+        public float size;
+        public int width;
+        public int height;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot2DHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot2DHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed3b964b6dea7ec489ea8aeee70792f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot3DHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot3DHandler.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    [Module("Scene")]
+    public sealed class SceneScreenshot3DHandler : CommandHandler<SceneScreenshot3DRequest, SceneScreenshotResponse>
+    {
+        public override string CommandName => "Scene.Screenshot3D";
+        public override string Description => "Capture a screenshot of the SceneView in 3D mode, orbiting a lookAt target by yaw/pitch/distance, and save as PNG";
+
+        protected override bool TryWriteFormatted(SceneScreenshotResponse response, bool success, IFormatWriter writer)
+            => SceneViewScreenshotUtility.TryWriteResult(response, success, writer);
+
+        protected override ValueTask<SceneScreenshotResponse> ExecuteAsync(SceneScreenshot3DRequest request, CancellationToken cancellationToken)
+        {
+            var sceneView = SceneViewScreenshotUtility.GetOrCreateSceneView();
+
+            var currentEuler = sceneView.rotation.eulerAngles;
+            var pitch = float.IsNaN(request.pitch) ? currentEuler.x : request.pitch;
+            var yaw = float.IsNaN(request.yaw) ? currentEuler.y : request.yaw;
+
+            var options = new SceneViewScreenshotUtility.CaptureOptions
+            {
+                orthographic = false,
+                pivot = SceneViewScreenshotUtility.ResolvePivot(sceneView, request.lookAt, request.offset, allowTwoComponentOffset: false),
+                rotation = Quaternion.Euler(pitch, yaw, 0f),
+                size = sceneView.size,
+                distance = request.distance,
+                width = request.width,
+                height = request.height
+            };
+
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Screenshots", $"sceneview3d_{DateTime.Now:yyyyMMdd_HHmmss}.png")
+                : request.path;
+            path = ResolvePath(path);
+
+            Texture2D texture = null;
+            try
+            {
+                texture = SceneViewScreenshotUtility.Capture(sceneView, options);
+                return new ValueTask<SceneScreenshotResponse>(SceneViewScreenshotUtility.SavePng(texture, path));
+            }
+            finally
+            {
+                if (texture != null)
+                    UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+    }
+
+    [Serializable]
+    public class SceneScreenshot3DRequest
+    {
+        public string path;
+        public string lookAt;
+        public float[] offset;
+        public float yaw = float.NaN;
+        public float pitch = float.NaN;
+        public float distance;
+        public int width;
+        public int height;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot3DHandler.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneScreenshot3DHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 925dfe7fd3bc35e4a8184a378ec99dcf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneViewScreenshotUtility.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneViewScreenshotUtility.cs
@@ -1,0 +1,189 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace UniCli.Server.Editor.Handlers
+{
+    internal static class SceneViewScreenshotUtility
+    {
+        public const int DefaultWidth = 1920;
+        public const int DefaultHeight = 1080;
+
+        internal struct CaptureOptions
+        {
+            public bool orthographic;
+            public Vector3 pivot;
+            public Quaternion rotation;
+            public float size;
+            public float distance;
+            public int width;
+            public int height;
+        }
+
+        public static SceneView GetOrCreateSceneView()
+        {
+            var sceneView = SceneView.lastActiveSceneView;
+            if (sceneView == null)
+                sceneView = EditorWindow.GetWindow<SceneView>();
+            if (sceneView == null || sceneView.camera == null)
+                throw new InvalidOperationException("No SceneView is available");
+            return sceneView;
+        }
+
+        public static Vector3 ResolvePivot(SceneView sceneView, string lookAt, float[] offset, bool allowTwoComponentOffset)
+        {
+            var pivot = sceneView.pivot;
+            if (!string.IsNullOrEmpty(lookAt))
+            {
+                var target = GameObjectResolver.ResolveByPath(lookAt);
+                if (target == null)
+                    throw new ArgumentException($"GameObject not found: \"{lookAt}\"");
+                pivot = target.transform.position;
+            }
+
+            if (offset != null && offset.Length > 0)
+            {
+                var valid = offset.Length == 3 || (allowTwoComponentOffset && offset.Length == 2);
+                if (!valid)
+                {
+                    throw new ArgumentException(allowTwoComponentOffset
+                        ? $"offset must have 2 or 3 components, got {offset.Length}"
+                        : $"offset must have 3 components, got {offset.Length}");
+                }
+
+                pivot += new Vector3(offset[0], offset[1], offset.Length > 2 ? offset[2] : 0f);
+            }
+
+            return pivot;
+        }
+
+        public static Texture2D Capture(SceneView sceneView, CaptureOptions options)
+        {
+            var width = options.width > 0 ? options.width : DefaultWidth;
+            var height = options.height > 0 ? options.height : DefaultHeight;
+
+            var renderTexture = RenderTexture.GetTemporary(width, height, 24, RenderTextureFormat.ARGB32);
+            var cameraObject = new GameObject("UniCliSceneViewCapture") { hideFlags = HideFlags.HideAndDontSave };
+            var previousActive = RenderTexture.active;
+            try
+            {
+                var camera = cameraObject.AddComponent<Camera>();
+                camera.enabled = false;
+                camera.CopyFrom(sceneView.camera);
+                camera.cameraType = CameraType.Game;
+                // The SceneView camera may use an explicit projection matrix baked with the
+                // window's aspect ratio; reset so the requested resolution drives projection.
+                camera.ResetWorldToCameraMatrix();
+                camera.ResetProjectionMatrix();
+                camera.targetTexture = renderTexture;
+                camera.aspect = (float)width / height;
+                camera.orthographic = options.orthographic;
+
+                float distance;
+                if (options.orthographic)
+                {
+                    camera.orthographicSize = options.size;
+                    distance = options.distance > 0f ? options.distance : options.size * 2f;
+                }
+                else
+                {
+                    distance = options.distance > 0f
+                        ? options.distance
+                        : options.size / Mathf.Tan(camera.fieldOfView * 0.5f * Mathf.Deg2Rad);
+                }
+
+                camera.transform.SetPositionAndRotation(
+                    options.pivot - options.rotation * Vector3.forward * distance,
+                    options.rotation);
+                camera.nearClipPlane = Mathf.Max(0.01f, distance * 0.0005f);
+                camera.farClipPlane = Mathf.Max(1000f, distance * 100f);
+
+                Render(camera, renderTexture);
+
+                RenderTexture.active = renderTexture;
+                var texture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+                texture.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                texture.Apply();
+                return texture;
+            }
+            finally
+            {
+                RenderTexture.active = previousActive;
+                RenderTexture.ReleaseTemporary(renderTexture);
+                UnityEngine.Object.DestroyImmediate(cameraObject);
+            }
+        }
+
+        private static void Render(Camera camera, RenderTexture destination)
+        {
+            if (GraphicsSettings.currentRenderPipeline != null)
+            {
+                // Camera.Render is unsupported on scriptable render pipelines (URP/HDRP).
+                var request = new RenderPipeline.StandardRequest { destination = destination };
+                if (RenderPipeline.SupportsRenderRequest(camera, request))
+                {
+                    RenderPipeline.SubmitRenderRequest(camera, request);
+                    return;
+                }
+            }
+
+            camera.Render();
+        }
+
+        public static SceneScreenshotResponse SavePng(Texture2D texture, string path)
+        {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            File.WriteAllBytes(path, texture.EncodeToPNG());
+
+            var fullPath = Path.GetFullPath(path);
+            if (!File.Exists(fullPath))
+                throw new InvalidOperationException($"Failed to save screenshot to: {fullPath}");
+
+            var fileInfo = new FileInfo(fullPath);
+            return new SceneScreenshotResponse
+            {
+                path = fullPath,
+                width = texture.width,
+                height = texture.height,
+                size = fileInfo.Length
+            };
+        }
+
+        public static bool TryWriteResult(SceneScreenshotResponse response, bool success, IFormatWriter writer)
+        {
+            if (success)
+            {
+                writer.WriteLine($"Screenshot saved to: {response.path}");
+                writer.WriteLine($"  Resolution: {response.width}x{response.height}");
+                writer.WriteLine($"  Size: {FormatBytes(response.size)}");
+            }
+            else
+            {
+                writer.WriteLine("Failed to capture SceneView screenshot");
+            }
+            return true;
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024L) return $"{bytes} B";
+            if (bytes < 1024L * 1024) return $"{bytes / 1024.0:F1} KB";
+            if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+            return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
+        }
+    }
+
+    [Serializable]
+    public class SceneScreenshotResponse
+    {
+        public string path;
+        public int width;
+        public int height;
+        public long size;
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneViewScreenshotUtility.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Scene/SceneViewScreenshotUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b3fee4926d804d4fa66a3679c89cce9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/SceneScreenshotHandlerTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/SceneScreenshotHandlerTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UniCli.Protocol;
+using UniCli.Server.Editor.Handlers;
+using UnityEngine;
+
+namespace UniCli.Server.Editor.Tests
+{
+    [TestFixture]
+    public class SceneScreenshotHandlerTests
+    {
+        private readonly List<GameObject> _createdObjects = new();
+        private readonly List<string> _createdFiles = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (var i = _createdObjects.Count - 1; i >= 0; i--)
+            {
+                if (_createdObjects[i] != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(_createdObjects[i]);
+                }
+            }
+
+            _createdObjects.Clear();
+
+            foreach (var file in _createdFiles)
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+
+            _createdFiles.Clear();
+        }
+
+        [Test]
+        public void Screenshot2D_SavesPngWithRequestedDimensions()
+        {
+            var path = CreateTempPath();
+            var response = ExecuteAsync(new SceneScreenshot2DHandler(), "Scene.Screenshot2D", new SceneScreenshot2DRequest
+            {
+                path = path,
+                offset = new[] { 1f, 2f },
+                size = 5f,
+                width = 320,
+                height = 240
+            }).GetAwaiter().GetResult();
+
+            Assert.IsTrue(File.Exists(response.path));
+            Assert.AreEqual(320, response.width);
+            Assert.AreEqual(240, response.height);
+            Assert.Greater(response.size, 0);
+        }
+
+        [Test]
+        public void Screenshot3D_SavesPngWithRequestedDimensions()
+        {
+            var path = CreateTempPath();
+            var response = ExecuteAsync(new SceneScreenshot3DHandler(), "Scene.Screenshot3D", new SceneScreenshot3DRequest
+            {
+                path = path,
+                yaw = 45f,
+                pitch = 30f,
+                distance = 10f,
+                width = 320,
+                height = 240
+            }).GetAwaiter().GetResult();
+
+            Assert.IsTrue(File.Exists(response.path));
+            Assert.AreEqual(320, response.width);
+            Assert.AreEqual(240, response.height);
+            Assert.Greater(response.size, 0);
+        }
+
+        [Test]
+        public void Screenshot3D_LookAtResolvesGameObject()
+        {
+            var target = new GameObject($"SceneScreenshotHandlerTests_{Guid.NewGuid():N}");
+            target.transform.position = new Vector3(10f, 20f, 30f);
+            _createdObjects.Add(target);
+
+            var path = CreateTempPath();
+            var response = ExecuteAsync(new SceneScreenshot3DHandler(), "Scene.Screenshot3D", new SceneScreenshot3DRequest
+            {
+                path = path,
+                lookAt = target.name,
+                offset = new[] { 0f, 1f, 0f },
+                yaw = 90f,
+                pitch = 45f,
+                distance = 5f,
+                width = 320,
+                height = 240
+            }).GetAwaiter().GetResult();
+
+            Assert.IsTrue(File.Exists(response.path));
+        }
+
+        [Test]
+        public void Screenshot3D_LookAtNotFound_Throws()
+        {
+            var path = CreateTempPath();
+            Assert.Throws<ArgumentException>(() =>
+                ExecuteAsync(new SceneScreenshot3DHandler(), "Scene.Screenshot3D", new SceneScreenshot3DRequest
+                {
+                    path = path,
+                    lookAt = $"NonExistentObject_{Guid.NewGuid():N}",
+                    yaw = 0f,
+                    pitch = 0f
+                }).GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Screenshot2D_InvalidOffsetLength_Throws()
+        {
+            var path = CreateTempPath();
+            Assert.Throws<ArgumentException>(() =>
+                ExecuteAsync(new SceneScreenshot2DHandler(), "Scene.Screenshot2D", new SceneScreenshot2DRequest
+                {
+                    path = path,
+                    offset = new[] { 1f }
+                }).GetAwaiter().GetResult());
+        }
+
+        private async Task<SceneScreenshotResponse> ExecuteAsync<TRequest>(ICommandHandler handler, string command, TRequest request)
+        {
+            var result = await handler.ExecuteAsync(
+                new CommandRequest
+                {
+                    command = command,
+                    data = JsonUtility.ToJson(request),
+                    format = "json"
+                },
+                CancellationToken.None);
+
+            return (SceneScreenshotResponse)result;
+        }
+
+        private string CreateTempPath()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"unicli_test_{Guid.NewGuid():N}.png");
+            _createdFiles.Add(path);
+            return path;
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/SceneScreenshotHandlerTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/SceneScreenshotHandlerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d12c3b56817d84b43b67a0524dd04b32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds `Scene.Screenshot2D` and `Scene.Screenshot3D` commands to capture the SceneView in 2D and 3D modes. Works in both EditMode and PlayMode. Shared a new class `SceneViewScreenshotUtility` handles camera-copy rendering.

## Commands

### `Scene.Screenshot2D`

| Parameter | Type | Description |
|---|---|---|
| `lookAt` | string | GameObject hierarchy path to use as capture center. Omit to keep the current SceneView pivot. |
| `offset` | float[2\|3] | World-space offset added to the `lookAt` position. `[x,y]` or `[x,y,z]`. |
| `size` | float | Orthographic half-height (zoom level). Defaults to current SceneView size. |
| `width` | int | Output image width in pixels. Default: 1920. |
| `height` | int | Output image height in pixels. Default: 1080. |
| `path` | string | Output PNG path. Default: `Screenshots/sceneview2d_yyyyMMdd_HHmmss.png`. |

```bash
# Top-down map view centered on Player, 5-unit orthographic radius
unicli exec Scene.Screenshot2D '{"lookAt":"Player","size":5,"path":"Screenshots/map.png"}' --json

# Offset the pivot 1 unit to the right of the target
unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path":"Screenshots/map.png"}' --json
```

### `Scene.Screenshot3D`


| Parameter  | Type     | Description                                                                          |
| ---------- | -------- | ------------------------------------------------------------------------------------ |
| `lookAt`   | string   | GameObject hierarchy path to orbit around. Omit to keep the current SceneView pivot. |
| `offset`   | float[3] | World-space offset added to the `lookAt` position.                                   |
| `yaw`      | float    | Horizontal orbit angle in degrees (0 = looking from −Z toward +Z).                   |
| `pitch`    | float    | Vertical angle in degrees (positive = camera tilts down).                            |
| `distance` | float    | Camera distance from the pivot. Defaults to current SceneView distance.              |
| `width`    | int      | Output image width in pixels. Default: 1920.                                         |
| `height`   | int      | Output image height in pixels. Default: 1080.                                        |
| `path`     | string   | Output PNG path. Default: `Screenshots/sceneview3d_yyyyMMdd_HHmmss.png`.             |

```bash
# 3/4 view from above-right at 10 units
unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json

# Only change yaw, keep current pitch/distance/pivot
unicli exec Scene.Screenshot3D '{"yaw":90}' --json
```

## Example Artifact
<img width="1920" height="1080" alt="elephant_nature_back34" src="https://github.com/user-attachments/assets/6b41264c-bdd1-4cfb-9338-65a6ad9dac5a" />

Prompt: Place a pink elephant made of primitive boxes in a nature-rich scene and capture it from various angles. (Sonnet 4.6)
