### PR TITLE
Release v1.5.0

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.4.1"
+  version: "1.5.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.4.1"
+  version: "1.5.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.4.1</Version>
+    <Version>1.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
### Summary

Prepares the `v1.5.0` minor release.

This release includes the Unity 6.5 EntityId compatibility work merged in #156. It bumps the CLI, Unity package, Claude plugin, and local agent skill metadata versions from `1.4.1` to `1.5.0`.

### Impact

- Updates the CLI package version to `1.5.0`.
- Updates `com.yucchiy.unicli-server` package metadata to `1.5.0`.
- Updates Claude plugin marketplace and skill metadata to `1.5.0`.
- Updates local agent skill metadata to `1.5.0`.
- Includes Unity 6.5 compatibility by routing live Unity object ids through `UnityObjectIdentity` and Unity 6.5 `EntityId` APIs.
- Includes 64-bit `instanceId` / `componentInstanceId` handling for Unity 6.5, with ids treated as opaque session-scoped int64 handles.
- Includes the `samples/UniCli.Samples.Unity6.5` project for multi-version verification.

### Tests

- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/package.json" --json` → success.
- `dotnet format UniCli.slnx --verify-no-changes --verbosity diagnostic` → success.
- `DOTNET_ROLL_FORWARD=Major dotnet test UniCli.slnx` → `52 passed`, `6 skipped`.
- `dotnet build src/UniCli.Protocol` → success with `0 Warning(s)`, `0 Error(s)`.
- `dotnet publish src/UniCli.Client -o .build` → success with existing nullable / AOT / linker warnings.
- `.build/unicli --version` → `1.5.0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0` after Unity launch retry.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `87 passed`, `0 failed`.
- `UNICLI_PROJECT=samples/UniCli.Samples.Unity6.5 .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0` after Unity launch retry.
- `git diff --check` → success.

### Unresolved

- After this PR is merged, create and push the release tag: `git tag v1.5.0 && git push origin v1.5.0`.
