### PR TITLE
Fix TestRunner hang when the test framework aborts a run

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/TestRunner/TestRunnerHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/TestRunner/TestRunnerHandler.cs
@@ -206,7 +206,7 @@ namespace UniCli.Server.Editor.Handlers
         public int stackTraceLines = 0; // 0: no stack trace (default), -1: full, N>0: first N lines
     }
 
-    internal class TestRunnerCallbacks : ICallbacks
+    internal class TestRunnerCallbacks : IErrorCallbacks
     {
         private readonly TaskCompletionSource<TestRunnerResponse> _tcs;
         private readonly System.Collections.Generic.List<TestResult> _testResults = new();
@@ -233,7 +233,7 @@ namespace UniCli.Server.Editor.Handlers
 
         public void RunFinished(ITestResultAdaptor result)
         {
-            _tcs.SetResult(new TestRunnerResponse
+            _tcs.TrySetResult(new TestRunnerResponse
             {
                 passed = _passedCount,
                 failed = _failedCount,
@@ -241,6 +241,11 @@ namespace UniCli.Server.Editor.Handlers
                 total = _passedCount + _failedCount + _skippedCount,
                 results = _testResults.ToArray()
             });
+        }
+
+        public void OnError(string message)
+        {
+            _tcs.TrySetException(new InvalidOperationException($"Test run aborted: {message}"));
         }
 
         public void TestStarted(ITestAdaptor test)

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/TestRunner/TestRunnerHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/TestRunner/TestRunnerHandler.cs
@@ -116,7 +116,7 @@ namespace UniCli.Server.Editor.Handlers
 
         protected override async ValueTask<TestRunnerResponse> ExecuteAsync(TestRunRequest request, CancellationToken cancellationToken)
         {
-            using var scope = _guard.BeginScope(CommandName, GuardCondition.NotCompiling);
+            using var scope = _guard.BeginScope(CommandName, GuardCondition.NotPlayingOrCompiling);
             return await TestRunnerHelper.RunTestsAsync(TestMode.PlayMode, request, cancellationToken);
         }
     }

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/TestRunnerCallbacksTests.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/TestRunnerCallbacksTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UniCli.Protocol;
+using UniCli.Server.Editor.Handlers;
+using UnityEditor.TestTools.TestRunner.Api;
+
+namespace UniCli.Server.Editor.Tests
+{
+    [TestFixture]
+    public class TestRunnerCallbacksTests
+    {
+        [Test]
+        public void TestRunnerCallbacks_OnError_FaultsTask()
+        {
+            var tcs = new TaskCompletionSource<TestRunnerResponse>();
+            var callbacks = (IErrorCallbacks)new TestRunnerCallbacks(tcs);
+
+            callbacks.OnError("boom");
+
+            Assert.That(tcs.Task.IsFaulted, Is.True);
+            var exception = tcs.Task.Exception?.GetBaseException();
+            Assert.That(exception, Is.TypeOf<InvalidOperationException>());
+            Assert.That(exception.Message, Is.EqualTo("Test run aborted: boom"));
+        }
+
+        [Test]
+        public void TestRunnerCallbacks_RunFinishedAfterOnError_DoesNotThrow()
+        {
+            var tcs = new TaskCompletionSource<TestRunnerResponse>();
+            var callbacks = new TestRunnerCallbacks(tcs);
+            ((IErrorCallbacks)callbacks).OnError("boom");
+
+            Assert.DoesNotThrow(() => callbacks.RunFinished(null));
+            Assert.That(tcs.Task.IsFaulted, Is.True);
+        }
+    }
+}

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/TestRunnerCallbacksTests.cs.meta
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Tests/Editor/TestRunnerCallbacksTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92352c1689ca24487afd36c74adedcfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implement `IErrorCallbacks` on `TestRunnerCallbacks` so that when the Unity Test Framework aborts a run without calling `RunFinished` (build errors, `IPrebuildSetup` failures, or `TestJobRunner`'s "An unexpected error happened while running tests"), the pending `TaskCompletionSource` is faulted and `TestRunner.RunEditMode` / `RunPlayMode` return an error response (`Command failed: Test run aborted: <reason>`) instead of leaving the CLI waiting forever. The abort path (`TestJobRunner.ReportRunFailed` → `CallbacksDelegator.RunFailed` → `IErrorCallbacks.OnError`) was confirmed in the test-framework package sources.
- Change `RunFinished` from `SetResult` to `TrySetResult` so a completion after `OnError` cannot throw on double completion.
- Strengthen the `TestRunner.RunPlayMode` guard from `NotCompiling` to `NotPlayingOrCompiling`. Starting a PlayMode test run while the editor is already in play mode is unsupported by the test framework (its `SaveModifiedSceneTask` calls `EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo`, which throws `InvalidOperationException` during play mode), and this previously hung the CLI; now the command is rejected immediately with `Cannot execute 'TestRunner.RunPlayMode' while in Play Mode.`
- Add `TestRunnerCallbacksTests` (EditMode) covering the `OnError` fault path (exception type and message) and `RunFinished` after `OnError` not throwing.

## Impact
- No public surface changes: command names, `TestRunRequest` / `TestRunnerResponse` fields, CLI flags, exit codes for the existing pass/fail paths, and the wire format stay identical.
- New failure behavior 1: an aborted run now returns `success: false` with `Command failed: Test run aborted: <framework reason>` and a non-zero exit code (previously the CLI hung until killed).
- New failure behavior 2: `TestRunner.RunPlayMode` during play mode is rejected upfront (previously undefined behavior that hung via the abort path). `TestRunner.RunEditMode` already had the `NotPlaying` guard and is unchanged.
- The client is untouched: `PipeClient`'s two-phase timeout design (no timeout while waiting for the response after ACK, to support long test runs) is kept; the fix guarantees the server always responds instead.
- `RunFailed` → `IErrorCallbacks.OnError` delegation was confirmed in all test-framework versions resolved by this repo's projects: 1.1.33 (main, 2022.3 LTS sample), 1.6.0 and 1.7.0 (Unity 6 samples).

## Test
Verified on the main project (`src/UniCli.Unity`). Sample projects are pending (see Open items).

- Red (before implementation): `TestRunner.RunEditMode` → 87 passed / 2 failed, both new tests failing with the expected `InvalidCastException`.
- Green: `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → 0 errors (2 pre-existing warnings); `exec TestRunner.RunEditMode --json` → 89 passed / 0 failed.
- Guard change regression: same commands after the guard change → Compile 0 errors, 89 passed / 0 failed.
- Manual play-mode check: `PlayMode.Enter` → `exec TestRunner.RunPlayMode --json` → immediate `Cannot execute 'TestRunner.RunPlayMode' while in Play Mode.` with exit code 1, no hang → `PlayMode.Exit` returns to edit mode normally.
- Self review against the C#/Unity checklist (Level 1): no blocking findings; the change is localized to `TestRunnerHandler.cs` plus the new test file.

## Open items
- Multi-version verification on the sample projects (2022.3 LTS / Unity 6 LTS / Unity 6.5) is pending because their Unity Editors were not running. The `IErrorCallbacks` interface and the `RunFailed` → `OnError` delegation were confirmed in the resolved package sources for all three versions (1.1.33 / 1.6.0 / 1.7.0), so compile breakage is not expected; `exec Compile` + `exec TestRunner.RunEditMode` on each sample should be run before merge.
- The original reported scenario (play mode + dirty scene → `SaveModifiedSceneTask` exception) is now prevented upfront by the guard; the `OnError` path remains as the safety net for other abort causes (e.g. player build errors in PlayMode runs) and is covered by unit tests rather than a live abort reproduction.
