### PR TITLE
Release v1.6.0

### DIFF
--- a/.agents/skills/unity-development/SKILL.md
+++ b/.agents/skills/unity-development/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   `AssetDatabase.Import` after file changes and `Compile` verification after C#
   edits.
 metadata:
-  version: "1.5.0"
+  version: "1.6.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "unicli",
       "source": "./.claude-plugin/unicli",
       "description": "Control Unity Editor from Claude Code using UniCli CLI",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "author": {
         "name": "Yuichiro Mukai"
       },

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 compatibility: Requires unicli CLI installed and Unity Editor running with com.yucchiy.unicli-server package
 metadata:
   author: yucchiy
-  version: "1.5.0"
+  version: "1.6.0"
 ---
 
 # UniCli — Unity Editor CLI

--- a/src/UniCli.Client/UniCli.Client.csproj
+++ b/src/UniCli.Client/UniCli.Client.csproj
@@ -9,7 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RollForward>LatestMajor</RollForward>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yucchiy.unicli-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "displayName": "UniCli Server",
   "description": "Unity Editor plugin - Server for controlling Unity via CLI",
   "unity": "2022.3",


### PR DESCRIPTION
### Summary

Prepares the `v1.6.0` minor release.

This release includes the SceneView screenshot commands merged in #152, the TestRunner abort hang fix merged in #159, and the dirty-scene `dirtyAction` policy merged in #160. It bumps the CLI, Unity package, Claude plugin, and agent skill metadata versions from `1.5.0` to `1.6.0`.

### Impact

- Updates the CLI package version to `1.6.0`.
- Updates `com.yucchiy.unicli-server` package metadata to `1.6.0`.
- Updates Claude plugin marketplace / skill metadata and local agent skill metadata to `1.6.0`.
- Includes `Scene.Screenshot2D` / `Scene.Screenshot3D` commands for SceneView capture (#152, thanks @paq).
- Includes the TestRunner fix that returns an error response when the test framework aborts a run, and rejects `TestRunner.RunPlayMode` while already in Play Mode (#159). Previously the CLI could hang indefinitely.
- Includes the `dirtyAction` policy (#160). **Behavior change:** `Scene.Open`/`Scene.New` (single mode), `Scene.Close`, and `TestRunner.RunEditMode`/`RunPlayMode` now fail by default when a dirty scene would lose unsaved changes; pass `dirtyAction: "save"` (or `"discard"` for scene commands) to proceed. `Scene.Save` now rejects untitled scenes without `saveAsPath`. Scripts that relied on silent discard need to opt in explicitly.
- No wire-protocol changes; old CLI/server pairings keep the existing handshake behavior.

### Tests

- `dotnet format UniCli.slnx --verify-no-changes` → success.
- `DOTNET_ROLL_FORWARD=Major dotnet test UniCli.slnx` → `52 passed`, `6 skipped`.
- `dotnet build src/UniCli.Protocol` → success.
- `dotnet publish src/UniCli.Client -o .build` → success; `.build/unicli --version` → `1.6.0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec AssetDatabase.Import --path "Packages/com.yucchiy.unicli-server/package.json" --json` → success.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Compile --json` → `errorCount: 0`, `warningCount: 0`.
- `UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec TestRunner.RunEditMode --resultFilter none --json` → `111 passed`, `0 failed`.
- Unity 6 LTS / Unity 6.5 samples were verified green (`exec Compile` + `exec TestRunner.RunEditMode`) on the merged code before #160 landed; this branch only bumps version metadata.

### Unresolved

- After this PR is merged, create and push the release tag: `git tag v1.6.0 && git push origin v1.6.0`.
- After CI creates the GitHub Release, consider adding a release-notes callout for the `dirtyAction` behavior change (breaking for scripts that relied on silent discard).
