### PR TITLE
Add Game View screenshot capture in Edit Mode

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -128,6 +128,13 @@ unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path
 unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
 ```
 
+**Capture GameView screenshots:**
+
+```bash
+unicli exec Screenshot.CaptureEditMode --json  # Edit Mode
+unicli exec Screenshot.Capture --json          # Play Mode
+```
+
 **Inspect and modify settings:**
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,10 +254,13 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"wi
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.Status --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StopRecording --json
 
-# Screenshot operations (requires Play Mode)
+# Screenshot operations
+# Play Mode
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
+# Edit Mode
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.CaptureEditMode --json
 
 # Module management
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.List --json

--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Requires Unity Memory Profiler (`com.unity.memoryprofiler`). Use `MemorySnapshot
 | Command | Description |
 |---|---|
 | `Screenshot.Capture` | Capture Game View screenshot as PNG (requires Play Mode) |
+| `Screenshot.CaptureEditMode` | Capture Game View screenshot as PNG (requires Edit Mode) |
 | `Recorder.StartRecording` | Start recording Game View as video (requires Play Mode) |
 | `Recorder.StopRecording` | Stop the current video recording |
 | `Recorder.Status` | Get the current recording status |

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -2564,6 +2564,28 @@ Capture a screenshot of the Game View and save as PNG (requires Play Mode)
 
 ---
 
+### Screenshot.CaptureEditMode
+
+Capture a screenshot of the Game View and save as PNG (requires Edit Mode)
+
+**Parameters:**
+
+| Field | Type |
+|---|---|
+| `path` | `string` |
+| `superSize` | `int` |
+
+**Response:**
+
+| Field | Type |
+|---|---|
+| `path` | `string` |
+| `width` | `int` |
+| `height` | `int` |
+| `size` | `Int64` |
+
+---
+
 
 ## Search
 

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
@@ -135,6 +135,81 @@ namespace UniCli.Server.Editor.Handlers
         }
     }
 
+    public sealed class ScreenshotCaptureEditModeHandler : CommandHandler<ScreenshotCaptureRequest, ScreenshotCaptureResponse>
+    {
+        public override string CommandName => "Screenshot.CaptureEditMode";
+        public override string Description => "Capture a screenshot of the Game View and save as PNG (requires Edit Mode)";
+
+        protected override async ValueTask<ScreenshotCaptureResponse> ExecuteAsync(
+            ScreenshotCaptureRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (EditorApplication.isPlaying)
+                throw new InvalidOperationException("Screenshot.CaptureEditMode requires Edit Mode. Use Screenshot.Capture in Play Mode.");
+
+            var superSize = request.superSize > 0 ? request.superSize : 1;
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Screenshots", $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png")
+                : request.path;
+            path = ResolvePath(path);
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var gameViewType = typeof(EditorWindow).Assembly.GetType("UnityEditor.GameView");
+            var gameView = gameViewType == null ? null : EditorWindow.GetWindow(gameViewType);
+            if (gameView == null)
+                throw new InvalidOperationException("No Game View is available.");
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            var width = Screen.width * superSize;
+            var height = Screen.height * superSize;
+            ScreenCapture.CaptureScreenshot(path, superSize);
+            gameView.Repaint();
+            await WaitForFileAsync(path, gameView, cancellationToken);
+
+            var fullPath = Path.GetFullPath(path);
+            return new ScreenshotCaptureResponse
+            {
+                path = fullPath,
+                width = width,
+                height = height,
+                size = new FileInfo(fullPath).Length
+            };
+        }
+
+        private static Task WaitForFileAsync(string path, EditorWindow gameView, CancellationToken cancellationToken)
+        {
+            var completionSource = new TaskCompletionSource<bool>();
+            var completedFrames = 0;
+            EditorApplication.CallbackFunction update = null;
+            update = () =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    EditorApplication.update -= update;
+                    completionSource.TrySetCanceled(cancellationToken);
+                    return;
+                }
+
+                gameView.Repaint();
+                completedFrames = File.Exists(path) && new FileInfo(path).Length > 0
+                    ? completedFrames + 1
+                    : 0;
+                if (completedFrames < 2)
+                    return;
+
+                EditorApplication.update -= update;
+                completionSource.TrySetResult(true);
+            };
+            EditorApplication.update += update;
+            return completionSource.Task;
+        }
+    }
+
     [Serializable]
     public class ScreenshotCaptureRequest
     {


### PR DESCRIPTION
## Motivation

What I ultimately want is very simple: a way to capture the Game View while Unity is in Edit Mode.

This is useful when asking an AI agent to adjust post-processing, materials, lighting, or other visual settings. The agent needs screenshots to inspect the result, but entering Play Mode for every iteration is unnecessary overhead.

## About this implementation

To be completely transparent, this implementation was written by Codex (ChatGPT 5.6 Sol).

I have tested it locally and confirmed that it works for my use case. However, I am not confident enough in the Unity Editor internals involved to say that the implementation is correct, robust, or appropriate for this project.

The implementation adds `Screenshot.CaptureEditMode`, with usage such as:

```bash
unicli exec Screenshot.CaptureEditMode
```

It also supports path and superSize, similarly to the existing screenshot command.

## Note for maintainers

Please do not feel obligated to review or preserve this code if doing so would create more work than it saves.
I am completely fine with this implementation being rewritten, reduced to a reference, or discarded entirely. The main point of this PR is simply to communicate the use case:
I would like AI agents to be able to capture the current Game View without entering Play Mode.

If the feature makes sense but the implementation does not, I would be equally happy for this PR to serve only as a concrete example of the desired behavior.