### PR TITLE
Prevent UniCli server startup in AssetImportWorkers

### DIFF
--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/UniCliServerBootstrap.cs
@@ -46,6 +46,10 @@ namespace UniCli.Server.Editor
 
         static UniCliServerBootstrap()
         {
+            // Import workers share this project's PID file and pipe name with the visible editor.
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+                return;
+
             EnsurePidFile();
 
             EditorApplication.update -= Initialize;
@@ -55,6 +59,9 @@ namespace UniCli.Server.Editor
         private static void Initialize()
         {
             EditorApplication.update -= Initialize;
+
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+                return;
 
             RunServiceInstallers(Services);
 
@@ -75,6 +82,9 @@ namespace UniCli.Server.Editor
         public static void StartServer()
         {
             EditorApplication.update -= StartServer;
+
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+                return;
 
             if (_server != null)
                 return;
@@ -186,6 +196,10 @@ namespace UniCli.Server.Editor
         private static void OnAfterAssemblyReload()
         {
             AssemblyReloadEvents.afterAssemblyReload -= OnAfterAssemblyReload;
+
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+                return;
+
             EditorApplication.update += OnEditorUpdate;
 
             EditorApplication.update -= StartServer;


### PR DESCRIPTION
## Summary
- skip UniCli bootstrap in Unity AssetImportWorker processes
- prevent workers from racing the visible editor for `Library/UniCli/server.pid` and the project named pipe
- retain defensive guards across initialization, server start, and assembly-reload entry points

## Reproduction
On Unity 6000.3.17f1 with asset import workers, `[InitializeOnLoad]` runs `UniCliServerBootstrap` inside workers. Because workers share the project path with the visible editor, they also share UniCli's PID file and pipe name. A worker can overwrite `server.pid` and compete for the pipe, causing `unicli status` to report an AssetImportWorker PID instead of the visible editor.

Worker logs also showed a PID-file sharing violation and Unity's `!AssetDatabase::IsAssetImportWorkerProcess()` assertion while the bootstrap accessed editor state.

## Validation
- `dotnet format UniCli.slnx --verify-no-changes`
- `dotnet test src/UniCli.Client.Tests/UniCli.Client.Tests.csproj`: 50 passed, 8 platform-specific skipped, 0 failed
- Unity 6000.3.17f1 consumer project: compile completed with 0 errors; with four AssetImportWorkers active, `server.pid` and `unicli status.processId` remained the visible editor PID and `Editor.Status` succeeded