### PR TITLE
fix: stop escaping HTML-sensitive characters in JSON output

### DIFF
--- a/src/UniCli.Client.Tests/OutputWriterTests.cs
+++ b/src/UniCli.Client.Tests/OutputWriterTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+
+namespace UniCli.Client.Tests;
+
+public class OutputWriterTests
+{
+    // System.Text.Json's default encoder escapes these for HTML-embedding safety,
+    // which renders Unity console logs unreadable (e.g. "it's obsolete").
+    private const string Special = "it's <b>bold</b> & \"quoted\"";
+
+    // `"` is still escaped as `\"` on output — that is JSON syntax, not the HTML encoder.
+    private const string SpecialAsJsonContent = "it's <b>bold</b> & \\\"quoted\\\"";
+
+    private static string Render(string json) =>
+        Encoding.UTF8.GetString(OutputWriter.RenderPrettyJson(json));
+
+    private static string RenderEnvelope(CliResult result) =>
+        Encoding.UTF8.GetString(OutputWriter.RenderJson(result));
+
+    [Fact]
+    public void PrettyJsonDoesNotEscapeHtmlSensitiveCharacters()
+    {
+        var output = Render($$"""{"message":{{System.Text.Json.JsonSerializer.Serialize(Special)}}}""");
+
+        Assert.Contains(SpecialAsJsonContent, output);
+        Assert.DoesNotContain("\\u", output);
+    }
+
+    [Fact]
+    public void PrettyJsonPreservesNonAsciiCharacters()
+    {
+        var output = Render("""{"message":"日本語"}""");
+
+        Assert.Contains("日本語", output);
+        Assert.DoesNotContain("\\u", output);
+    }
+
+    [Fact]
+    public void JsonEnvelopeDoesNotEscapeHtmlSensitiveCharacters()
+    {
+        var result = CliResult.Ok("done", $$"""{"message":{{System.Text.Json.JsonSerializer.Serialize(Special)}}}""");
+
+        var output = RenderEnvelope(result);
+
+        Assert.Contains(SpecialAsJsonContent, output);
+        Assert.DoesNotContain("\\u", output);
+    }
+
+    [Fact]
+    public void JsonEnvelopeEscapesFormattedTextWithoutUnicodeEscapes()
+    {
+        var result = new CliResult { Success = true, Message = "done", FormattedText = Special };
+
+        var output = RenderEnvelope(result);
+
+        Assert.Contains(SpecialAsJsonContent, output);
+        Assert.DoesNotContain("\\u", output);
+    }
+}

--- a/src/UniCli.Client/OutputWriter.cs
+++ b/src/UniCli.Client/OutputWriter.cs
@@ -1,11 +1,21 @@
 using System;
 using System.Buffers;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace UniCli.Client;
 
 internal static class OutputWriter
 {
+    // The default JavaScriptEncoder escapes ' < > & " as \uXXXX for HTML-embedding
+    // safety, which makes console logs and other Unity strings unreadable on stdout.
+    // CLI output is never embedded in HTML, so use the relaxed encoder.
+    private static readonly JsonWriterOptions WriterOptions = new()
+    {
+        Indented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     public static int Write(CliResult result, bool json)
     {
         if (json)
@@ -18,8 +28,13 @@ internal static class OutputWriter
 
     private static void WriteJson(CliResult result)
     {
+        WriteToStdout(RenderJson(result));
+    }
+
+    internal static byte[] RenderJson(CliResult result)
+    {
         var buffer = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true });
+        using var writer = new Utf8JsonWriter(buffer, WriterOptions);
 
         writer.WriteStartObject();
         writer.WriteBoolean("success", result.Success);
@@ -51,10 +66,7 @@ internal static class OutputWriter
         writer.WriteEndObject();
         writer.Flush();
 
-        using var stdout = Console.OpenStandardOutput();
-        stdout.Write(buffer.WrittenSpan);
-        stdout.Flush();
-        Console.WriteLine();
+        return buffer.WrittenSpan.ToArray();
     }
 
     private static void WriteHuman(CliResult result)
@@ -79,14 +91,24 @@ internal static class OutputWriter
 
     private static void WritePrettyJson(string json)
     {
+        WriteToStdout(RenderPrettyJson(json));
+    }
+
+    internal static byte[] RenderPrettyJson(string json)
+    {
         using var doc = JsonDocument.Parse(json);
         var buffer = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true });
+        using var writer = new Utf8JsonWriter(buffer, WriterOptions);
         doc.RootElement.WriteTo(writer);
         writer.Flush();
 
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteToStdout(byte[] bytes)
+    {
         using var stdout = Console.OpenStandardOutput();
-        stdout.Write(buffer.WrittenSpan);
+        stdout.Write(bytes);
         stdout.Flush();
         Console.WriteLine();
     }


### PR DESCRIPTION
`Utf8JsonWriter` defaults to `JavaScriptEncoder.Default`, which escapes `'`, `<`, `>`, `&` and all non-ASCII as `\uXXXX` so the output is safe to embed in HTML. CLI output never gets embedded in HTML, so the escaping only costs readability.

It shows up worst in `Console.GetLog`, because compiler diagnostics quote identifiers:

```json
"message": "warning CS0618: 'FindObjectsSortMode' is obsolete"
```

Non-ASCII goes the same way, so Japanese log output comes back as a run of escapes:

```json
"message": "日本語"
```

After the change:

```json
"message": "warning CS0618: 'FindObjectsSortMode' is obsolete"
"message": "日本語"
```

`"` is still escaped as `\"` — that is JSON syntax, not the encoder.

## Change

Both `Utf8JsonWriter` instances in `OutputWriter` now share a `JsonWriterOptions` with `Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping`. Despite the name, "unsafe" here only means unsafe to embed directly in HTML/JS; the output is still valid JSON, and it stays correctly escaped for JSON itself.

`OutputWriter` is the single choke point for command output, so this covers `exec`, `commands --json` and the `--json` envelope together. Values that arrive pre-escaped from the server are re-parsed by `JsonDocument.Parse` before being rewritten, so they are unescaped on the way through.

I also split the rendering out of the stdout writes (`RenderJson` / `RenderPrettyJson` returning `byte[]`), so the encoding can be asserted without capturing the console. That is the only reason for the refactor.

## Tests

Four tests in `OutputWriterTests` cover the envelope and pretty-print paths, for both HTML-sensitive ASCII and non-ASCII. I checked they fail without the encoder change — reverting just that line fails exactly those four.

Full suite: 56 passed, 6 skipped (platform-specific).

Verified end-to-end against a running Editor with the 1.6.0 server package.
