### PR TITLE
Support Edit Mode capture in Screenshot.Capture with mode parameter

### DIFF
--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -128,6 +128,13 @@ unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path
 unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
 ```
 
+**Capture GameView screenshots:**
+
+```bash
+unicli exec Screenshot.CaptureEditMode --json  # Edit Mode
+unicli exec Screenshot.Capture --json          # Play Mode
+```
+
 **Inspect and modify settings:**
 
 ```bash

--- a/.claude-plugin/unicli/skills/unity-development/SKILL.md
+++ b/.claude-plugin/unicli/skills/unity-development/SKILL.md
@@ -128,11 +128,12 @@ unicli exec Scene.Screenshot2D '{"lookAt":"Player","offset":[1,0],"size":5,"path
 unicli exec Scene.Screenshot3D '{"lookAt":"Player","yaw":45,"pitch":30,"distance":10,"path":"Screenshots/shot.png"}' --json
 ```
 
-**Capture GameView screenshots:**
+**Capture Game View screenshots (Edit Mode or Play Mode):**
 
 ```bash
-unicli exec Screenshot.CaptureEditMode --json  # Edit Mode
-unicli exec Screenshot.Capture --json          # Play Mode
+unicli exec Screenshot.Capture --json                    # capture in the current mode
+unicli exec Screenshot.Capture '{"mode":"edit"}' --json  # error if the editor is in Play Mode
+unicli exec Screenshot.Capture '{"mode":"play"}' --json  # error if the editor is in Edit Mode
 ```
 
 **Inspect and modify settings:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,10 +254,13 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"wi
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.Status --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StopRecording --json
 
-# Screenshot operations (requires Play Mode)
+# Screenshot operations
+# Play Mode
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
+# Edit Mode
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.CaptureEditMode --json
 
 # Module management
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.List --json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,13 +254,12 @@ UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StartRecording '{"wi
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.Status --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Recorder.StopRecording --json
 
-# Screenshot operations
-# Play Mode
+# Screenshot operations (captures the Game View in the current mode; pin with "mode")
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/test.png"}' --json
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"path":"Screenshots/hires.png","superSize":2}' --json
-# Edit Mode
-UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.CaptureEditMode --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"mode":"edit"}' --json
+UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Screenshot.Capture '{"mode":"play"}' --json
 
 # Module management
 UNICLI_PROJECT=src/UniCli.Unity .build/unicli exec Module.List --json

--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Requires Unity Memory Profiler (`com.unity.memoryprofiler`). Use `MemorySnapshot
 | Command | Description |
 |---|---|
 | `Screenshot.Capture` | Capture Game View screenshot as PNG (requires Play Mode) |
+| `Screenshot.CaptureEditMode` | Capture Game View screenshot as PNG (requires Edit Mode) |
 | `Recorder.StartRecording` | Start recording Game View as video (requires Play Mode) |
 | `Recorder.StopRecording` | Stop the current video recording |
 | `Recorder.Status` | Get the current recording status |

--- a/README.md
+++ b/README.md
@@ -690,8 +690,7 @@ Requires Unity Memory Profiler (`com.unity.memoryprofiler`). Use `MemorySnapshot
 
 | Command | Description |
 |---|---|
-| `Screenshot.Capture` | Capture Game View screenshot as PNG (requires Play Mode) |
-| `Screenshot.CaptureEditMode` | Capture Game View screenshot as PNG (requires Edit Mode) |
+| `Screenshot.Capture` | Capture Game View screenshot as PNG (Edit Mode or Play Mode; pin with `mode`) |
 | `Recorder.StartRecording` | Start recording Game View as video (requires Play Mode) |
 | `Recorder.StopRecording` | Stop the current video recording |
 | `Recorder.Status` | Get the current recording status |

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -2564,6 +2564,28 @@ Capture a screenshot of the Game View and save as PNG (requires Play Mode)
 
 ---
 
+### Screenshot.CaptureEditMode
+
+Capture a screenshot of the Game View and save as PNG (requires Edit Mode)
+
+**Parameters:**
+
+| Field | Type |
+|---|---|
+| `path` | `string` |
+| `superSize` | `int` |
+
+**Response:**
+
+| Field | Type |
+|---|---|
+| `path` | `string` |
+| `width` | `int` |
+| `height` | `int` |
+| `size` | `Int64` |
+
+---
+
 
 ## Search
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -2544,7 +2544,7 @@ Set the active scene via SceneManager
 
 ### Screenshot.Capture
 
-Capture a screenshot of the Game View and save as PNG (requires Play Mode)
+Capture a screenshot of the Game View and save as PNG (works in both Edit Mode and Play Mode)
 
 **Parameters:**
 
@@ -2552,34 +2552,14 @@ Capture a screenshot of the Game View and save as PNG (requires Play Mode)
 |---|---|
 | `path` | `string` |
 | `superSize` | `int` |
+| `mode` | `string` |
 
 **Response:**
 
 | Field | Type |
 |---|---|
 | `path` | `string` |
-| `width` | `int` |
-| `height` | `int` |
-| `size` | `Int64` |
-
----
-
-### Screenshot.CaptureEditMode
-
-Capture a screenshot of the Game View and save as PNG (requires Edit Mode)
-
-**Parameters:**
-
-| Field | Type |
-|---|---|
-| `path` | `string` |
-| `superSize` | `int` |
-
-**Response:**
-
-| Field | Type |
-|---|---|
-| `path` | `string` |
+| `mode` | `string` |
 | `width` | `int` |
 | `height` | `int` |
 | `size` | `Int64` |

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
@@ -135,6 +135,81 @@ namespace UniCli.Server.Editor.Handlers
         }
     }
 
+    public sealed class ScreenshotCaptureEditModeHandler : CommandHandler<ScreenshotCaptureRequest, ScreenshotCaptureResponse>
+    {
+        public override string CommandName => "Screenshot.CaptureEditMode";
+        public override string Description => "Capture a screenshot of the Game View and save as PNG (requires Edit Mode)";
+
+        protected override async ValueTask<ScreenshotCaptureResponse> ExecuteAsync(
+            ScreenshotCaptureRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (EditorApplication.isPlaying)
+                throw new InvalidOperationException("Screenshot.CaptureEditMode requires Edit Mode. Use Screenshot.Capture in Play Mode.");
+
+            var superSize = request.superSize > 0 ? request.superSize : 1;
+            var path = string.IsNullOrEmpty(request.path)
+                ? Path.Combine("Screenshots", $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png")
+                : request.path;
+            path = ResolvePath(path);
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var gameViewType = typeof(EditorWindow).Assembly.GetType("UnityEditor.GameView");
+            var gameView = gameViewType == null ? null : EditorWindow.GetWindow(gameViewType);
+            if (gameView == null)
+                throw new InvalidOperationException("No Game View is available.");
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            var width = Screen.width * superSize;
+            var height = Screen.height * superSize;
+            ScreenCapture.CaptureScreenshot(path, superSize);
+            gameView.Repaint();
+            await WaitForFileAsync(path, gameView, cancellationToken);
+
+            var fullPath = Path.GetFullPath(path);
+            return new ScreenshotCaptureResponse
+            {
+                path = fullPath,
+                width = width,
+                height = height,
+                size = new FileInfo(fullPath).Length
+            };
+        }
+
+        private static Task WaitForFileAsync(string path, EditorWindow gameView, CancellationToken cancellationToken)
+        {
+            var completionSource = new TaskCompletionSource<bool>();
+            var completedFrames = 0;
+            EditorApplication.CallbackFunction update = null;
+            update = () =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    EditorApplication.update -= update;
+                    completionSource.TrySetCanceled(cancellationToken);
+                    return;
+                }
+
+                gameView.Repaint();
+                completedFrames = File.Exists(path) && new FileInfo(path).Length > 0
+                    ? completedFrames + 1
+                    : 0;
+                if (completedFrames < 2)
+                    return;
+
+                EditorApplication.update -= update;
+                completionSource.TrySetResult(true);
+            };
+            EditorApplication.update += update;
+            return completionSource.Task;
+        }
+    }
+
     [Serializable]
     public class ScreenshotCaptureRequest
     {

--- a/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
+++ b/src/UniCli.Unity/Packages/com.yucchiy.unicli-server/Editor/Handlers/Screenshot/ScreenshotCaptureHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -7,16 +8,24 @@ using UnityEngine;
 
 namespace UniCli.Server.Editor.Handlers
 {
+    internal enum ScreenshotCaptureMode
+    {
+        Auto,
+        Edit,
+        Play,
+    }
+
     public sealed class ScreenshotCaptureHandler : CommandHandler<ScreenshotCaptureRequest, ScreenshotCaptureResponse>
     {
         public override string CommandName => "Screenshot.Capture";
-        public override string Description => "Capture a screenshot of the Game View and save as PNG (requires Play Mode)";
+        public override string Description => "Capture a screenshot of the Game View and save as PNG (works in both Edit Mode and Play Mode)";
 
         protected override bool TryWriteFormatted(ScreenshotCaptureResponse response, bool success, IFormatWriter writer)
         {
             if (success)
             {
                 writer.WriteLine($"Screenshot saved to: {response.path}");
+                writer.WriteLine($"  Mode: {response.mode}");
                 writer.WriteLine($"  Resolution: {response.width}x{response.height}");
                 writer.WriteLine($"  Size: {FormatBytes(response.size)}");
             }
@@ -37,8 +46,15 @@ namespace UniCli.Server.Editor.Handlers
 
         protected override async ValueTask<ScreenshotCaptureResponse> ExecuteAsync(ScreenshotCaptureRequest request, CancellationToken cancellationToken)
         {
-            if (!EditorApplication.isPlaying)
-                throw new InvalidOperationException("Screenshot.Capture requires Play Mode. Use PlayMode.Enter first.");
+            var requestedMode = ParseMode(request.mode);
+            var isPlaying = EditorApplication.isPlaying;
+
+            if (requestedMode == ScreenshotCaptureMode.Edit && isPlaying)
+                throw new InvalidOperationException(
+                    $"'{CommandName}' with mode \"edit\" requires Edit Mode, but the editor is in Play Mode. Use PlayMode.Exit first, or omit mode to capture the current mode.");
+            if (requestedMode == ScreenshotCaptureMode.Play && !isPlaying)
+                throw new InvalidOperationException(
+                    $"'{CommandName}' with mode \"play\" requires Play Mode. Use PlayMode.Enter first, or omit mode to capture the current mode.");
 
             var superSize = request.superSize > 0 ? request.superSize : 1;
 
@@ -51,39 +67,57 @@ namespace UniCli.Server.Editor.Handlers
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                 Directory.CreateDirectory(directory);
 
-            int capturedWidth;
-            int capturedHeight;
-            Texture2D tex = null;
-            try
-            {
-                tex = await CaptureScreenshotAsync(superSize, cancellationToken);
-                capturedWidth = tex.width;
-                capturedHeight = tex.height;
-                var pngBytes = tex.EncodeToPNG();
-                File.WriteAllBytes(path, pngBytes);
-            }
-            finally
-            {
-                if (tex != null)
-                    UnityEngine.Object.DestroyImmediate(tex);
-            }
+            var (width, height) = isPlaying
+                ? await CapturePlayModeAsync(path, superSize, cancellationToken)
+                : EditModeGameViewCapture.Capture(path, superSize);
 
             var fullPath = Path.GetFullPath(path);
 
             if (!File.Exists(fullPath))
                 throw new InvalidOperationException($"Failed to save screenshot to: {fullPath}");
 
-            var fileInfo = new FileInfo(fullPath);
             return new ScreenshotCaptureResponse
             {
                 path = fullPath,
-                width = capturedWidth,
-                height = capturedHeight,
-                size = fileInfo.Length
+                mode = isPlaying ? "play" : "edit",
+                width = width,
+                height = height,
+                size = new FileInfo(fullPath).Length
             };
         }
 
-        private static async Task<Texture2D> CaptureScreenshotAsync(int superSize, CancellationToken cancellationToken)
+        private ScreenshotCaptureMode ParseMode(string mode)
+        {
+            if (string.IsNullOrEmpty(mode) || string.Equals(mode, "auto", StringComparison.OrdinalIgnoreCase))
+                return ScreenshotCaptureMode.Auto;
+
+            if (string.Equals(mode, "edit", StringComparison.OrdinalIgnoreCase))
+                return ScreenshotCaptureMode.Edit;
+
+            if (string.Equals(mode, "play", StringComparison.OrdinalIgnoreCase))
+                return ScreenshotCaptureMode.Play;
+
+            throw new ArgumentException(
+                $"Invalid mode \"{mode}\" for '{CommandName}'. Valid values: \"auto\" (default), \"edit\", \"play\".");
+        }
+
+        private static async Task<(int width, int height)> CapturePlayModeAsync(string path, int superSize, CancellationToken cancellationToken)
+        {
+            Texture2D texture = null;
+            try
+            {
+                texture = await CapturePlayModeTextureAsync(superSize, cancellationToken);
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+                return (texture.width, texture.height);
+            }
+            finally
+            {
+                if (texture != null)
+                    UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+
+        private static async Task<Texture2D> CapturePlayModeTextureAsync(int superSize, CancellationToken cancellationToken)
         {
             var gameObject = new GameObject("UniCliScreenshotCaptureRunner")
             {
@@ -135,78 +169,178 @@ namespace UniCli.Server.Editor.Handlers
         }
     }
 
-    public sealed class ScreenshotCaptureEditModeHandler : CommandHandler<ScreenshotCaptureRequest, ScreenshotCaptureResponse>
+    /// <summary>
+    /// Captures the Game View in Edit Mode by rendering the game cameras
+    /// directly into the view's target texture through the same internal entry
+    /// point the Game View uses when it repaints.
+    ///
+    /// ScreenCapture.CaptureScreenshot is not used here on purpose: its file is
+    /// only written when the Game View actually repaints, which never happens
+    /// while the editor application is in the background — the normal state when
+    /// an agent drives the editor through UniCli.
+    /// </summary>
+    internal static class EditModeGameViewCapture
     {
-        public override string CommandName => "Screenshot.CaptureEditMode";
-        public override string Description => "Capture a screenshot of the Game View and save as PNG (requires Edit Mode)";
+        private const BindingFlags MemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
-        protected override async ValueTask<ScreenshotCaptureResponse> ExecuteAsync(
-            ScreenshotCaptureRequest request,
-            CancellationToken cancellationToken)
+        public static (int width, int height) Capture(string path, int superSize)
         {
-            if (EditorApplication.isPlaying)
-                throw new InvalidOperationException("Screenshot.CaptureEditMode requires Edit Mode. Use Screenshot.Capture in Play Mode.");
+            var editorAssembly = typeof(EditorWindow).Assembly;
+            var playModeViewType = editorAssembly.GetType("UnityEditor.PlayModeView");
+            if (playModeViewType == null)
+                throw new InvalidOperationException("Edit Mode capture is not supported: UnityEditor.PlayModeView is unavailable in this Unity version.");
 
-            var superSize = request.superSize > 0 ? request.superSize : 1;
-            var path = string.IsNullOrEmpty(request.path)
-                ? Path.Combine("Screenshots", $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png")
-                : request.path;
-            path = ResolvePath(path);
+            var view = GetOrCreateGameView(editorAssembly, playModeViewType);
 
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrEmpty(directory))
-                Directory.CreateDirectory(directory);
+            // Outside a Repaint event RenderView only (re)configures and returns
+            // the view's target texture without drawing into it; the actual
+            // rendering is requested explicitly below.
+            var viewTexture = InvokeRenderView(playModeViewType, view);
+            var targetDisplay = GetTargetDisplay(playModeViewType, view);
 
-            var gameViewType = typeof(EditorWindow).Assembly.GetType("UnityEditor.GameView");
-            var gameView = gameViewType == null ? null : EditorWindow.GetWindow(gameViewType);
-            if (gameView == null)
-                throw new InvalidOperationException("No Game View is available.");
-
-            if (File.Exists(path))
-                File.Delete(path);
-
-            var width = Screen.width * superSize;
-            var height = Screen.height * superSize;
-            ScreenCapture.CaptureScreenshot(path, superSize);
-            gameView.Repaint();
-            await WaitForFileAsync(path, gameView, cancellationToken);
-
-            var fullPath = Path.GetFullPath(path);
-            return new ScreenshotCaptureResponse
+            RenderTexture scaledTexture = null;
+            try
             {
-                path = fullPath,
-                width = width,
-                height = height,
-                size = new FileInfo(fullPath).Length
-            };
-        }
-
-        private static Task WaitForFileAsync(string path, EditorWindow gameView, CancellationToken cancellationToken)
-        {
-            var completionSource = new TaskCompletionSource<bool>();
-            var completedFrames = 0;
-            EditorApplication.CallbackFunction update = null;
-            update = () =>
-            {
-                if (cancellationToken.IsCancellationRequested)
+                var target = viewTexture;
+                if (superSize > 1)
                 {
-                    EditorApplication.update -= update;
-                    completionSource.TrySetCanceled(cancellationToken);
-                    return;
+                    var descriptor = viewTexture.descriptor;
+                    descriptor.width = viewTexture.width * superSize;
+                    descriptor.height = viewTexture.height * superSize;
+                    scaledTexture = new RenderTexture(descriptor);
+                    if (!scaledTexture.Create())
+                        throw new InvalidOperationException($"Failed to create a {descriptor.width}x{descriptor.height} render texture for superSize={superSize}.");
+                    target = scaledTexture;
                 }
 
-                gameView.Repaint();
-                completedFrames = File.Exists(path) && new FileInfo(path).Length > 0
-                    ? completedFrames + 1
-                    : 0;
-                if (completedFrames < 2)
-                    return;
+                // Game cameras take their viewport from the display view size,
+                // which stays at its 640x480 default until the Game View has
+                // repainted at least once; align it with the capture target so
+                // the cameras fill the whole texture, then restore it.
+                using (DisplayViewSizeScope.Apply(playModeViewType, view, targetDisplay, target.width, target.height))
+                {
+                    RenderGameViewCameras(target, targetDisplay);
+                }
 
-                EditorApplication.update -= update;
-                completionSource.TrySetResult(true);
-            };
-            EditorApplication.update += update;
-            return completionSource.Task;
+                WritePng(target, path);
+                return (target.width, target.height);
+            }
+            finally
+            {
+                if (scaledTexture != null)
+                    UnityEngine.Object.DestroyImmediate(scaledTexture);
+            }
+        }
+
+        private static EditorWindow GetOrCreateGameView(Assembly editorAssembly, Type playModeViewType)
+        {
+            var getMainPlayModeView = playModeViewType.GetMethod("GetMainPlayModeView", BindingFlags.Static | BindingFlags.NonPublic);
+            var view = getMainPlayModeView?.Invoke(null, null) as EditorWindow;
+            if (view != null)
+                return view;
+
+            var gameViewType = editorAssembly.GetType("UnityEditor.GameView");
+            if (gameViewType == null)
+                throw new InvalidOperationException("The Unity Game View type is unavailable.");
+
+            view = EditorWindow.GetWindow(gameViewType, false, "Game", false);
+            if (view == null)
+                throw new InvalidOperationException("No Game View is available.");
+            return view;
+        }
+
+        private static RenderTexture InvokeRenderView(Type playModeViewType, EditorWindow view)
+        {
+            var renderView = playModeViewType.GetMethod("RenderView", MemberFlags, null, new[] { typeof(Vector2), typeof(bool) }, null);
+            if (renderView == null)
+                throw new InvalidOperationException("Edit Mode capture is not supported: PlayModeView.RenderView is unavailable in this Unity version.");
+
+            var texture = renderView.Invoke(view, new object[] { Vector2.zero, true }) as RenderTexture;
+            if (texture == null)
+                throw new InvalidOperationException("The Game View did not provide a target texture to capture.");
+            return texture;
+        }
+
+        private static int GetTargetDisplay(Type playModeViewType, EditorWindow view)
+        {
+            var targetDisplay = playModeViewType.GetProperty("targetDisplay", MemberFlags);
+            return targetDisplay != null ? (int)targetDisplay.GetValue(view) : 0;
+        }
+
+        private static void RenderGameViewCameras(RenderTexture target, int targetDisplay)
+        {
+            var renderCameras = typeof(EditorGUIUtility).GetMethod("RenderPlayModeViewCamerasInternal", BindingFlags.Static | BindingFlags.NonPublic);
+            if (renderCameras == null)
+                throw new InvalidOperationException("Edit Mode capture is not supported: EditorGUIUtility.RenderPlayModeViewCamerasInternal is unavailable in this Unity version.");
+
+            renderCameras.Invoke(null, new object[] { target, targetDisplay, Vector2.zero, false, true });
+        }
+
+        private readonly struct DisplayViewSizeScope : IDisposable
+        {
+            private readonly MethodInfo _setDisplayViewSize;
+            private readonly EditorWindow _view;
+            private readonly int _targetDisplay;
+            private readonly Vector2 _originalSize;
+
+            private DisplayViewSizeScope(MethodInfo setDisplayViewSize, EditorWindow view, int targetDisplay, Vector2 originalSize)
+            {
+                _setDisplayViewSize = setDisplayViewSize;
+                _view = view;
+                _targetDisplay = targetDisplay;
+                _originalSize = originalSize;
+            }
+
+            public static DisplayViewSizeScope Apply(Type playModeViewType, EditorWindow view, int targetDisplay, int width, int height)
+            {
+                var setDisplayViewSize = playModeViewType.GetMethod("SetDisplayViewSize", MemberFlags);
+                var getDisplayViewSize = playModeViewType.GetMethod("GetDisplayViewSize", MemberFlags);
+                if (setDisplayViewSize == null || getDisplayViewSize == null)
+                    return default;
+
+                var originalSize = (Vector2)getDisplayViewSize.Invoke(view, new object[] { targetDisplay });
+                setDisplayViewSize.Invoke(view, new object[] { targetDisplay, new Vector2(width, height) });
+                return new DisplayViewSizeScope(setDisplayViewSize, view, targetDisplay, originalSize);
+            }
+
+            public void Dispose()
+            {
+                _setDisplayViewSize?.Invoke(_view, new object[] { _targetDisplay, _originalSize });
+            }
+        }
+
+        private static void WritePng(RenderTexture source, string path)
+        {
+            var previousActive = RenderTexture.active;
+            var texture = new Texture2D(source.width, source.height, TextureFormat.RGBA32, false);
+            try
+            {
+                RenderTexture.active = source;
+                texture.ReadPixels(new Rect(0, 0, source.width, source.height), 0, 0);
+                texture.Apply();
+
+                if (SystemInfo.graphicsUVStartsAtTop)
+                    FlipVertically(texture);
+
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+            }
+            finally
+            {
+                RenderTexture.active = previousActive;
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+
+        private static void FlipVertically(Texture2D texture)
+        {
+            var width = texture.width;
+            var height = texture.height;
+            var pixels = texture.GetPixels32();
+            var flipped = new Color32[pixels.Length];
+            for (var y = 0; y < height; y++)
+                Array.Copy(pixels, y * width, flipped, (height - 1 - y) * width, width);
+            texture.SetPixels32(flipped);
+            texture.Apply();
         }
     }
 
@@ -215,12 +349,14 @@ namespace UniCli.Server.Editor.Handlers
     {
         public string path;
         public int superSize;
+        public string mode = ""; // "auto" (default), "edit", "play"
     }
 
     [Serializable]
     public class ScreenshotCaptureResponse
     {
         public string path;
+        public string mode;
         public int width;
         public int height;
         public long size;


### PR DESCRIPTION
## Summary

`Screenshot.Capture` now captures the Game View in both Edit Mode and Play Mode. Previously it required Play Mode and failed otherwise.

This PR includes the original commit from #162 as-is (authored by @kyubuns) and reworks it in a follow-up commit, so the original contribution stays in the history.

This implements the use case from #162 (thanks @kyubuns): agents iterating on post-processing, materials, or lighting need Game View screenshots without entering Play Mode for every iteration. Following the discussion there (thanks @paq for the integration proposal), the Edit Mode path is integrated into the existing command instead of adding a separate `Screenshot.CaptureEditMode`, and an optional `mode` parameter keeps captures deterministic for agents that must not capture in an unintended mode.

## Interface

Anyone using `Screenshot.Capture` can now capture in Edit Mode; existing Play Mode usage keeps working unchanged. No caller migration is required.

| Surface | What changes | Impact on existing users | Notes |
|---|---|---|---|
| `Screenshot.Capture` request | New optional `mode` field: `"auto"` (default), `"edit"`, `"play"` | None — omitted `mode` behaves as `auto` | `"edit"` / `"play"` fail fast when the editor is in the other mode |
| `Screenshot.Capture` behavior | Works in Edit Mode instead of throwing "requires Play Mode" | Callers that relied on the Play Mode error as a mode check should pass `mode:"play"` | |
| `Screenshot.Capture` response | New `mode` field reporting the mode actually captured (`"edit"` / `"play"`) | Additive only | Lets agents verify the result without a separate `Editor.Status` call |

## Usage

Capture whatever the Game View currently shows (most common for agents; succeeds in both modes and reports which one was used):

```bash
unicli exec Screenshot.Capture '{"path":"Screenshots/shot.png"}' --json
# => {"path":"...","mode":"edit","width":1428,"height":1306,"size":240772}
```

Pin the capture to a specific mode when capturing in the wrong mode would be worse than failing (e.g. verifying Edit Mode lighting; fails with a clear error instead of capturing Play Mode state):

```bash
unicli exec Screenshot.Capture '{"mode":"edit"}' --json
# In Play Mode => Command failed: 'Screenshot.Capture' with mode "edit" requires Edit Mode...
```

`superSize` multiplies the capture resolution in both modes:

```bash
unicli exec Screenshot.Capture '{"mode":"edit","superSize":2}' --json
```

## How Edit Mode capture works

`ScreenCapture.CaptureScreenshot` (used by #162) writes its file only when the Game View repaints, and the Game View never repaints while the editor application is in the background — which is the normal state when an agent drives the editor. During verification it timed out consistently with the editor unfocused.

The Edit Mode path therefore renders the game cameras directly into the Game View's target texture through the same internal entry point the Game View repaint uses:

1. `PlayModeView.GetMainPlayModeView()` (reflection) resolves the Game View; one is created via `GetWindow` if none exists.
2. `PlayModeView.RenderView()` configures and returns the view's target `RenderTexture` (outside a Repaint event it configures without drawing).
3. The display view size is temporarily aligned to the capture target (`SetDisplayViewSize`) — it stays at a 640x480 default until the Game View first repaints, and game cameras take their viewport from it. Restored after rendering.
4. `EditorGUIUtility.RenderPlayModeViewCamerasInternal` renders the cameras into the target.
5. Pixels are read back, vertically flipped when `SystemInfo.graphicsUVStartsAtTop` (Metal/D3D), and encoded to PNG.

The Play Mode path (coroutine + `CaptureScreenshotAsTexture`) is unchanged.

## Scope of impact

| Area | Impact | Compatibility |
|---|---|---|
| Edit Mode capture | New capability; uses internal Unity APIs via reflection | Missing members throw a clear "not supported in this Unity version" error instead of failing silently |
| Play Mode capture | Code path unchanged | Same behavior as before |
| Response schema | `mode` field added | Additive; existing consumers unaffected |
| Docs | README / CLAUDE.md / doc/commands.md / plugin SKILL.md updated | — |

## Review focus

- Whether the `mode` parameter semantics (auto default, fail-fast on mismatch, mode echoed in response) are the right resolution of the #162 discussion
- The reflection surface in `EditModeGameViewCapture` (PlayModeView.RenderView / SetDisplayViewSize / RenderPlayModeViewCamerasInternal): acceptable for a tool that targets 2022.3+, and whether the per-version failure mode (explicit exception) is appropriate
- Restoring the display view size after capture — any editor state this could still perturb

## Tests

- `UNICLI_PROJECT=src/UniCli.Unity unicli exec Compile` → 0 errors (2 pre-existing unrelated warnings)
- `TestRunner.RunEditMode` → 111 passed / 0 failed (dev project, 2022.3.62f3)
- Manual verification on 2022.3.62f3 (dev project): Edit Mode auto / `mode:"edit"` / `superSize:2` capture (image content and orientation verified), Play Mode capture via `PlayMode.Enter` (`mode` reported `"play"`), `mode:"edit"` in Play Mode fails, `mode:"play"` in Edit Mode fails, invalid `mode` fails with the valid-values message
- Manual verification on samples: Unity 6 LTS (6000.0) Compile + Edit Mode capture incl. `superSize:2`; Unity 6.5 (6000.5) Compile + Edit Mode capture — full-frame content verified after the display-view-size fix (without it, cameras rendered only into a 640x480 corner)
- All Edit Mode captures were verified with the editor application unfocused (background), matching agent usage

## Open questions

- Screen Space - Overlay UI in Edit Mode capture is not explicitly verified (sample scenes have no canvas); worth a follow-up check with a UI-heavy scene
- SRP (URP/HDRP) projects are not covered by the sample matrix; the render path is the Game View's own, so it should match what the Game View shows, but this is unverified

Closes #162
